### PR TITLE
Dim background option in Volume overlay effect

### DIFF
--- a/Project-Aurora/Profiles/Overlays/VolumeOverlay/Event_VolumeOverlay.cs
+++ b/Project-Aurora/Profiles/Overlays/VolumeOverlay/Event_VolumeOverlay.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using Aurora.EffectsEngine;
 using NAudio.CoreAudioApi;
+using System.Drawing;
+using Aurora.Settings.Layers;
 
 namespace Aurora.Profiles.Overlays
 {
@@ -18,7 +20,7 @@ namespace Aurora.Profiles.Overlays
                 Queue<EffectLayer> layers = new Queue<EffectLayer>();
 
                 EffectLayer volume_bar = new EffectLayer("Overlay - Volume Bar");
-
+                
                 MMDeviceEnumerator devEnum = new MMDeviceEnumerator();
                 MMDevice defaultDevice = devEnum.GetDefaultAudioEndpoint(DataFlow.Render, Role.Console);
                 float currentVolume = defaultDevice.AudioEndpointVolume.MasterVolumeLevelScalar;
@@ -28,6 +30,12 @@ namespace Aurora.Profiles.Overlays
 
                 volume_bar.PercentEffect(volume_spec, Global.Configuration.volume_overlay_settings.sequence, currentVolume, 1.0f);
 
+                if (Global.Configuration.volume_overlay_settings.dim_background)
+                {
+                    EffectLayer volume_black_base = new EffectLayer("Overlay - Volume Base");
+                    volume_black_base.PercentEffect(new ColorSpectrum(Color.Black), Global.Configuration.volume_overlay_settings.sequence, 1, 1);
+                    layers.Enqueue(volume_black_base);
+                }
                 layers.Enqueue(volume_bar);
 
                 frame.AddOverlayLayers(layers.ToArray());

--- a/Project-Aurora/Profiles/Overlays/VolumeOverlay/Event_VolumeOverlay.cs
+++ b/Project-Aurora/Profiles/Overlays/VolumeOverlay/Event_VolumeOverlay.cs
@@ -33,7 +33,7 @@ namespace Aurora.Profiles.Overlays
                 if (Global.Configuration.volume_overlay_settings.dim_background)
                 {
                     EffectLayer volume_black_base = new EffectLayer("Overlay - Volume Base");
-                    volume_black_base.PercentEffect(new ColorSpectrum(Color.Black), Global.Configuration.volume_overlay_settings.sequence, 1, 1);
+                    volume_black_base.Fill(Color.Black);
                     layers.Enqueue(volume_black_base);
                 }
                 layers.Enqueue(volume_bar);

--- a/Project-Aurora/Profiles/Overlays/VolumeOverlay/VolumeOverlaySettings.cs
+++ b/Project-Aurora/Profiles/Overlays/VolumeOverlay/VolumeOverlaySettings.cs
@@ -13,6 +13,7 @@ namespace Aurora.Profiles.Overlays
         public Color med_color;
         public Color high_color;
         public int delay;
+        public bool dim_background;
 
         public VolumeOverlaySettings()
         {
@@ -28,6 +29,8 @@ namespace Aurora.Profiles.Overlays
             high_color = Color.Red;
 
             delay = 3;
+
+            dim_background = false;
         }
     }
 }

--- a/Project-Aurora/Settings/Control_Settings.xaml
+++ b/Project-Aurora/Settings/Control_Settings.xaml
@@ -164,6 +164,7 @@
                     <xctk:ColorPicker x:Name="volume_med_colorpicker" HorizontalAlignment="Left" Height="24" Margin="124,59,0,0" VerticalAlignment="Top" Width="116" ColorMode="ColorCanvas" SelectedColorChanged="volume_med_colorpicker_SelectedColorChanged"/>
                     <TextBlock HorizontalAlignment="Left" Margin="10,91,0,0" TextWrapping="Wrap" Text="High Level Color:" VerticalAlignment="Top"/>
                     <xctk:ColorPicker x:Name="volume_high_colorpicker" HorizontalAlignment="Left" Height="24" Margin="105,88,0,0" VerticalAlignment="Top" Width="135" ColorMode="ColorCanvas" SelectedColorChanged="volume_high_colorpicker_SelectedColorChanged"/>
+                    <CheckBox x:Name="volume_overlay_dim_background" Content="Dim background" HorizontalAlignment="Left" Margin="245,62,0,0" VerticalAlignment="Top" Checked="volume_overlay_dim_background_Checked" Unchecked="volume_overlay_dim_background_Checked"/>
                     <Controls:KeySequence x:Name="volume_ks" HorizontalAlignment="Left" Margin="10,117,0,0" VerticalAlignment="Top" Height="145" Title="Volume Overlay Keys" RecordingTag="Volume Overlay Keys" SequenceUpdated="volume_ks_SequenceUpdated"/>
                     <TextBlock HorizontalAlignment="Left" Margin="245,33,0,0" TextWrapping="Wrap" VerticalAlignment="Top"><Run Text="Delay:"/></TextBlock>
                     <TextBlock HorizontalAlignment="Left" TextWrapping="Wrap" Text="seconds" VerticalAlignment="Top" Margin="337,34,0,0"/>

--- a/Project-Aurora/Settings/Control_Settings.xaml.cs
+++ b/Project-Aurora/Settings/Control_Settings.xaml.cs
@@ -58,6 +58,7 @@ namespace Aurora.Settings
             this.volume_high_colorpicker.SelectedColor = Utils.ColorUtils.DrawingColorToMediaColor(Global.Configuration.volume_overlay_settings.high_color);
             this.volume_ks.Sequence = Global.Configuration.volume_overlay_settings.sequence;
             this.volume_effects_delay.Value = Global.Configuration.volume_overlay_settings.delay;
+            this.volume_overlay_dim_background.IsChecked = Global.Configuration.volume_overlay_settings.dim_background;
 
             this.skype_overlay_enabled.IsChecked = Global.Configuration.skype_overlay_settings.enabled;
             this.skype_unread_messages_enabled.IsChecked = Global.Configuration.skype_overlay_settings.mm_enabled;
@@ -945,6 +946,15 @@ namespace Aurora.Settings
             if (IsLoaded)
             {
                 Global.Configuration.atmoorb_ids = this.atmoorb_IDs.Text;
+                ConfigManager.Save(Global.Configuration);
+            }
+        }
+
+        private void volume_overlay_dim_background_Checked(object sender, RoutedEventArgs e)
+        {
+            if (IsLoaded)
+            {
+                Global.Configuration.volume_overlay_settings.dim_background = (this.volume_overlay_dim_background.IsChecked.HasValue) ? this.volume_overlay_dim_background.IsChecked.Value : false;
                 ConfigManager.Save(Global.Configuration);
             }
         }


### PR DESCRIPTION
I added an option to black out keys under the volume overlay area before applying the volume overlay effect itself. This way it's better seen on backgrounds where the effect would otherwise blend in, such as animated rainbow or solid green color.

It's working, but inefficiently using a gradient EffectLayer just for a solid black background, I basically just copied the procedure from the volume overlay itself, because I didn't delve into the code much. So maybe it's more appropriate to consider this as an feature request and change this PR to a proper implementation, with different variable nomenclature according to the codestyle etc.