### PR TITLE
Small fix EffectLayer.PercentEffect didn't use whole color spectrum.

### DIFF
--- a/Project-Aurora/EffectsEngine/EffectLayer.cs
+++ b/Project-Aurora/EffectsEngine/EffectLayer.cs
@@ -798,15 +798,15 @@ namespace Aurora.EffectsEngine
                         {
                             double percent = (double)progress - i;
                             SetOneKey(current_key,
-                                Utils.ColorUtils.MultiplyColorByScalar(spectrum.GetColorAt((float)i / (float)keys.Count(), 1.0f, flash_amount), percent)
+                                Utils.ColorUtils.MultiplyColorByScalar(spectrum.GetColorAt((float)i / (float)(keys.Count()-1), 1.0f, flash_amount), percent)
                                 );
                         }
                         else if (i < (int)progress)
-                            SetOneKey(current_key,spectrum.GetColorAt((float)i / (float)keys.Count(), 1.0f, flash_amount));
+                            SetOneKey(current_key,spectrum.GetColorAt((float)i / (float)(keys.Count() - 1), 1.0f, flash_amount));
                         break;
                     default:
                         if (i < (int)progress)
-                            SetOneKey(current_key,spectrum.GetColorAt((float)i / (float)keys.Count(), 1.0f, flash_amount));
+                            SetOneKey(current_key,spectrum.GetColorAt((float)i / (float)(keys.Count() - 1), 1.0f, flash_amount));
                         break;
                 }
             }


### PR DESCRIPTION
For example we have 5 keys for displaying percent effect. 
They have indexes 0-4. 
keys.Count() is 5.
Than for 100% we are taking color `(float)i / (float)(keys.Count()`  = 4/5 = 0.8 in spectrum.
Instead we should take `(float)i / (float)(keys.Count() - 1)` = 4/4 = 1 in spectrum
