### PR TITLE
New Color Enhancement Method with HSV

### DIFF
--- a/Project-Aurora/Profiles/Aurora Wrapper/GameEvent_Aurora_Wrapper.cs
+++ b/Project-Aurora/Profiles/Aurora Wrapper/GameEvent_Aurora_Wrapper.cs
@@ -25,8 +25,8 @@ namespace Aurora.Profiles.Aurora_Wrapper
         internal bool colorEnhance_Enabled = false;
         internal int colorEnhance_Mode = 0;
         internal int colorEnhance_color_factor = 90;
-        internal float colorEnhance_color_simple = 1.2f;
-        internal float colorEnhance_color_gamma = 2.5f;
+        internal float colorEnhance_color_hsv_sine = 0.1f;
+        internal float colorEnhance_color_hsv_gamma = 2.5f;
 
         protected virtual void UpdateExtraLights(Queue<EffectLayer> layers)
         {
@@ -368,6 +368,85 @@ namespace Aurora.Profiles.Aurora_Wrapper
             return Global.Configuration.allow_all_logitech_bitmaps;
         }
 
+        public float[] RgbToHsv(Color colorRgb)
+        {
+            float R = colorRgb.R / 255.0f;
+            float G = colorRgb.G / 255.0f;
+            float B = colorRgb.B / 255.0f;
+
+            float M = Math.Max(Math.Max(R, G), B);
+            float m = Math.Min(Math.Min(R, G), B);
+            float C = M - m;
+
+            float H = 0.0f;
+            if (M == R)
+                H = (G - B) / C % 6;
+            else if (M == G)
+                H = (B - R) / C + 2;
+            else if (M == B)
+                H = (R - G) / C + 4;
+            H *= 60.0f;
+
+            float V = M;
+            float S = 0;
+            if (V != 0)
+                S = C / V;
+
+            return new float[] { H, S, V };
+        }
+
+        public Color HsvToRgb(float[] colorHsv)
+        {
+            double H = colorHsv[0] / 60.0;
+            float S = colorHsv[1];
+            float V = colorHsv[2];
+
+            float C = V * S;
+
+            float[] rgb = new float[] { 0, 0, 0 };
+
+            float X = (float)(C * (1 - Math.Abs(H % 2 - 1)));
+            Console.WriteLine("C> " + C);
+            Console.WriteLine("X> " + X);
+
+            int i = (int)Math.Floor(H);
+            switch (i)
+            {
+                case 0:
+                case 6:
+                    rgb = new float[] { C, X, 0 };
+                    break;
+                case 1:
+                    rgb = new float[] { X, C, 0 };
+                    break;
+                case 2:
+                    rgb = new float[] { 0, C, X };
+                    break;
+                case 3:
+                    rgb = new float[] { 0, X, C };
+                    break;
+                case 4:
+                    rgb = new float[] { X, 0, C };
+                    break;
+                case 5:
+                case -1:
+                    rgb = new float[] { C, 0, X };
+                    break;
+            }
+            float m = V - C;
+
+            return Color.FromArgb(Clamp((int)((rgb[0] + m) * 255 + 0.5f)), Clamp((int)((rgb[1] + m) * 255 + 0.5f)), Clamp((int)((rgb[2] + m) * 255 + 0.5f)));
+        }
+
+        private int Clamp(int n)
+        {
+            if (n <= 0)
+                return 0;
+            if (n >= 255)
+                return 255;
+            return n;
+        }
+
         private Color GetBoostedColor(Color color)
         {
             if (!colorEnhance_Enabled)
@@ -386,32 +465,15 @@ namespace Aurora.Profiles.Aurora_Wrapper
                     return Utils.ColorUtils.MultiplyColorByScalar(color, boost_amount);
 
                 case 1:
-                    float redComp = color.R * colorEnhance_color_simple;
-                    float greenComp = color.G * colorEnhance_color_simple;
-                    float blueComp = color.B * colorEnhance_color_simple;
+                    float[] colorHsv = RgbToHsv(color);
+                    float X = colorEnhance_color_hsv_sine;
+                    float Y = 1.0f / colorEnhance_color_hsv_gamma;
+                    colorHsv[2] = (float)Math.Min(1, (double)(Math.Pow(X * Math.Sin(2 * Math.PI * colorHsv[2]) + colorHsv[2], Y)));
+                    return HsvToRgb(colorHsv);
 
-                    float maxComp = Math.Max(Math.Max(redComp, greenComp), blueComp);
-                    if (maxComp < 256)
-                        return Color.FromArgb(color.A, (int)redComp, (int)greenComp, (int)blueComp);
-                    float sumComp = redComp + greenComp + blueComp;
-                    if (sumComp >= 768)
-                        return Color.FromArgb(color.A, 255, 255, 255);
-                    float x = (3 * 255.999f - sumComp) / (3 * maxComp - sumComp);
-                    float gray = 255.999f - x * maxComp;
-
-                    return Color.FromArgb(color.A, (int)(gray + x * redComp), (int)(gray + x * greenComp), (int)(gray + x * blueComp));
-
-                case 2:
-                    byte colorRed = (byte)Math.Min(255, (int)((255.0 * Math.Pow(color.R / 255.0, 1.0 / colorEnhance_color_gamma)) + 0.5));
-                    byte colorGreen = (byte)Math.Min(255, (int)((255.0 * Math.Pow(color.G / 255.0, 1.0 / colorEnhance_color_gamma)) + 0.5));
-                    byte colorBlue = (byte)Math.Min(255, (int)((255.0 * Math.Pow(color.B / 255.0, 1.0 / colorEnhance_color_gamma)) + 0.5));
-
-                    return Color.FromArgb(color.A, colorRed, colorGreen, colorBlue);
-                    
                 default:
                     return color;
             }
-            // initial_factor * (1 - (x / color_factor))
         }
     }
 

--- a/Project-Aurora/Profiles/Blade and Soul/BnSSettings.cs
+++ b/Project-Aurora/Profiles/Blade and Soul/BnSSettings.cs
@@ -10,8 +10,8 @@ namespace Aurora.Profiles.Blade_and_Soul
         public bool colorEnhance_Enabled;
         public int colorEnhance_Mode;
         public int colorEnhance_color_factor;
-        public float colorEnhance_color_simple;
-        public float colorEnhance_color_gamma;
+        public float colorEnhance_color_hsv_sine;
+        public float colorEnhance_color_hsv_gamma;
 
         public BnSSettings()
         {
@@ -23,8 +23,8 @@ namespace Aurora.Profiles.Blade_and_Soul
             colorEnhance_Enabled = true;
             colorEnhance_Mode = 0;
             colorEnhance_color_factor = 90;
-            colorEnhance_color_simple = 1.2f;
-            colorEnhance_color_gamma = 2.5f;
+            colorEnhance_color_hsv_sine = 0.1f;
+            colorEnhance_color_hsv_gamma = 2.5f;
         }
     }
 }

--- a/Project-Aurora/Profiles/Blade and Soul/BnSSettings.cs
+++ b/Project-Aurora/Profiles/Blade and Soul/BnSSettings.cs
@@ -8,8 +8,10 @@ namespace Aurora.Profiles.Blade_and_Soul
         //Effects
         //// Color Enhancing
         public bool colorEnhance_Enabled;
-        public float colorEnhance_initial_factor;
+        public int colorEnhance_Mode;
         public int colorEnhance_color_factor;
+        public float colorEnhance_color_simple;
+        public float colorEnhance_color_gamma;
 
         public BnSSettings()
         {
@@ -19,8 +21,10 @@ namespace Aurora.Profiles.Blade_and_Soul
             //Effects
             //// Color Enhancing
             colorEnhance_Enabled = true;
-            colorEnhance_initial_factor = 3.0f;
+            colorEnhance_Mode = 0;
             colorEnhance_color_factor = 90;
+            colorEnhance_color_simple = 1.2f;
+            colorEnhance_color_gamma = 2.5f;
         }
     }
 }

--- a/Project-Aurora/Profiles/Blade and Soul/Control_BnS.xaml
+++ b/Project-Aurora/Profiles/Blade and Soul/Control_BnS.xaml
@@ -35,9 +35,21 @@
             <TabItem Header="Color Enhancing">
                 <Grid>
                     <CheckBox x:Name="ce_enabled" Content="Enable Color Enhancing" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" Checked="ce_enabled_Checked" Unchecked="ce_enabled_Checked"/>
-                    <TextBlock HorizontalAlignment="Left" Margin="10,30,0,0" TextWrapping="Wrap" Text="Color Factor:" VerticalAlignment="Top"/>
-                    <Slider x:Name="ce_color_factor" HorizontalAlignment="Left" Margin="82,30,0,0" VerticalAlignment="Top" Width="200" Minimum="1" Maximum="255" Value="90" ValueChanged="ce_color_factor_ValueChanged"/>
-                    <TextBlock x:Name="ce_color_factor_label" HorizontalAlignment="Left" Margin="287,33,0,0" TextWrapping="Wrap" Text="255" VerticalAlignment="Top"/>
+                    <TextBlock Text="Color Enhancing Mode:" Margin="20,33,0,0" VerticalAlignment="Top" HorizontalAlignment="Left"/>
+                    <ComboBox x:Name="ce_mode" HorizontalAlignment="Left" Margin="149,30,0,0" VerticalAlignment="Top" Width="120" SelectedIndex="0" SelectionChanged="ce_mode_SelectionChanged">
+                        <ComboBoxItem Content="Linear"/>
+                        <ComboBoxItem Content="Simple" ToolTip="Simple multiplication with color restribution."/>
+                        <ComboBoxItem Content="Gamma" ToolTip="Using normal image gamma correction. It affects "/>
+                    </ComboBox>
+                    <TextBlock HorizontalAlignment="Left" Margin="20,57,0,0" TextWrapping="Wrap" Text="Color Factor:" VerticalAlignment="Top"/>
+                    <Slider x:Name="ce_color_factor" HorizontalAlignment="Left" Margin="101,57,0,0" VerticalAlignment="Top" Width="200" Minimum="1" Maximum="255" Value="90" ValueChanged="ce_color_factor_ValueChanged"/>
+                    <TextBlock x:Name="ce_color_factor_label" HorizontalAlignment="Left" Margin="306,57,0,0" TextWrapping="Wrap" Text="255" VerticalAlignment="Top"/>
+                    <TextBlock HorizontalAlignment="Left" Margin="20,80,0,0" TextWrapping="Wrap" Text="Simple Factor:" VerticalAlignment="Top"/>
+                    <Slider x:Name="ce_color_simple" HorizontalAlignment="Left" Margin="101,80,0,0" VerticalAlignment="Top" Width="200" Minimum="1.0" Maximum="2" Value="1.2" ValueChanged="ce_color_simple_ValueChanged" IsSnapToTickEnabled="True" TickFrequency="0.05"/>
+                    <TextBlock x:Name="ce_color_simple_label" HorizontalAlignment="Left" Margin="306,80,0,0" TextWrapping="Wrap" Text="2.0" VerticalAlignment="Top"/>
+                    <TextBlock HorizontalAlignment="Left" Margin="20,103,0,0" TextWrapping="Wrap" Text="Gamma Value:" VerticalAlignment="Top"/>
+                    <Slider x:Name="ce_color_gamma" HorizontalAlignment="Left" Margin="101,103,0,0" VerticalAlignment="Top" Width="200" Minimum="1.0" Maximum="4.0" Value="2.0" ValueChanged="ce_color_gamma_ValueChanged" IsSnapToTickEnabled="True" TickFrequency="0.1"/>
+                    <TextBlock x:Name="ce_color_gamma_label" HorizontalAlignment="Left" Margin="306,103,0,0" TextWrapping="Wrap" Text="4.0" VerticalAlignment="Top"/>
                 </Grid>
             </TabItem>
         </TabControl>

--- a/Project-Aurora/Profiles/Blade and Soul/Control_BnS.xaml
+++ b/Project-Aurora/Profiles/Blade and Soul/Control_BnS.xaml
@@ -38,18 +38,18 @@
                     <TextBlock Text="Color Enhancing Mode:" Margin="20,33,0,0" VerticalAlignment="Top" HorizontalAlignment="Left"/>
                     <ComboBox x:Name="ce_mode" HorizontalAlignment="Left" Margin="149,30,0,0" VerticalAlignment="Top" Width="120" SelectedIndex="0" SelectionChanged="ce_mode_SelectionChanged">
                         <ComboBoxItem Content="Linear"/>
-                        <ComboBoxItem Content="Simple" ToolTip="Simple multiplication with color restribution."/>
-                        <ComboBoxItem Content="Gamma" ToolTip="Using normal image gamma correction. It affects "/>
+                        <ComboBoxItem Content="HSV"/>
                     </ComboBox>
                     <TextBlock HorizontalAlignment="Left" Margin="20,57,0,0" TextWrapping="Wrap" Text="Color Factor:" VerticalAlignment="Top"/>
-                    <Slider x:Name="ce_color_factor" HorizontalAlignment="Left" Margin="101,57,0,0" VerticalAlignment="Top" Width="200" Minimum="1" Maximum="255" Value="90" ValueChanged="ce_color_factor_ValueChanged"/>
-                    <TextBlock x:Name="ce_color_factor_label" HorizontalAlignment="Left" Margin="306,57,0,0" TextWrapping="Wrap" Text="255" VerticalAlignment="Top"/>
-                    <TextBlock HorizontalAlignment="Left" Margin="20,80,0,0" TextWrapping="Wrap" Text="Simple Factor:" VerticalAlignment="Top"/>
-                    <Slider x:Name="ce_color_simple" HorizontalAlignment="Left" Margin="101,80,0,0" VerticalAlignment="Top" Width="200" Minimum="1.0" Maximum="2" Value="1.2" ValueChanged="ce_color_simple_ValueChanged" IsSnapToTickEnabled="True" TickFrequency="0.05"/>
-                    <TextBlock x:Name="ce_color_simple_label" HorizontalAlignment="Left" Margin="306,80,0,0" TextWrapping="Wrap" Text="2.0" VerticalAlignment="Top"/>
-                    <TextBlock HorizontalAlignment="Left" Margin="20,103,0,0" TextWrapping="Wrap" Text="Gamma Value:" VerticalAlignment="Top"/>
-                    <Slider x:Name="ce_color_gamma" HorizontalAlignment="Left" Margin="101,103,0,0" VerticalAlignment="Top" Width="200" Minimum="1.0" Maximum="4.0" Value="2.0" ValueChanged="ce_color_gamma_ValueChanged" IsSnapToTickEnabled="True" TickFrequency="0.1"/>
-                    <TextBlock x:Name="ce_color_gamma_label" HorizontalAlignment="Left" Margin="306,103,0,0" TextWrapping="Wrap" Text="4.0" VerticalAlignment="Top"/>
+                    <Slider x:Name="ce_color_factor" HorizontalAlignment="Left" Margin="126,57,0,0" VerticalAlignment="Top" Width="200" Minimum="1" Maximum="255" Value="90" ValueChanged="ce_color_factor_ValueChanged"/>
+                    <TextBlock x:Name="ce_color_factor_label" HorizontalAlignment="Left" Margin="331,57,0,0" TextWrapping="Wrap" Text="255" VerticalAlignment="Top"/>
+                    <TextBlock HorizontalAlignment="Left" Margin="20,80,0,0" TextWrapping="Wrap" Text="HSV Sine Factor:" VerticalAlignment="Top" ToolTip="Changes the factor on how much the sine applies to the Formula, which makes darker colors brighter and bright colors darker. Higher values have a greater impact."/>
+                    <Slider x:Name="ce_color_hsv_sine" HorizontalAlignment="Left" Margin="126,80,0,0" VerticalAlignment="Top" Width="200" Minimum="0.0" Maximum="0.16" Value="0.1" ValueChanged="ce_color_hsv_sine_ValueChanged" IsSnapToTickEnabled="True" TickFrequency="0.02"/>
+                    <TextBlock x:Name="ce_color_hsv_sine_label" HorizontalAlignment="Left" Margin="335,80,0,0" TextWrapping="Wrap" Text="0.1" VerticalAlignment="Top"/>
+                    <TextBlock HorizontalAlignment="Left" Margin="20,103,0,0" TextWrapping="Wrap" Text="HSV Gamma Value:" VerticalAlignment="Top" ToolTip="Changes the factor for overall stronger colors. It cancels out the effect of the option above in the upper half of the brightness spectrum."/>
+                    <Slider x:Name="ce_color_hsv_gamma" HorizontalAlignment="Left" Margin="126,103,0,0" VerticalAlignment="Top" Width="200" Minimum="1.0" Maximum="4.0" Value="1.5" ValueChanged="ce_color_hsv_gamma_ValueChanged" IsSnapToTickEnabled="True" TickFrequency="0.05"/>
+                    <TextBlock x:Name="ce_color_hsv_gamma_label" HorizontalAlignment="Left" Margin="335,103,0,0" TextWrapping="Wrap" Text="1.5" VerticalAlignment="Top"/>
+                    <TextBlock TextWrapping="Wrap" Text="HSV is an advanced algorithm to make to colors look brighter. It uses the following Formula to calculate" Margin="37,143,0,0" HorizontalAlignment="Left" Width="190" VerticalAlignment="Top"/>
                 </Grid>
             </TabItem>
         </TabControl>

--- a/Project-Aurora/Profiles/Blade and Soul/Control_BnS.xaml.cs
+++ b/Project-Aurora/Profiles/Blade and Soul/Control_BnS.xaml.cs
@@ -37,8 +37,13 @@ namespace Aurora.Profiles.Blade_and_Soul
 
             this.game_enabled.IsChecked = (profile_manager.Settings as BnSSettings).isEnabled;
             this.ce_enabled.IsChecked = (profile_manager.Settings as BnSSettings).colorEnhance_Enabled;
+            this.ce_mode.SelectedIndex = (profile_manager.Settings as BnSSettings).colorEnhance_Mode;
             this.ce_color_factor.Value = (profile_manager.Settings as BnSSettings).colorEnhance_color_factor;
             this.ce_color_factor_label.Text = (profile_manager.Settings as BnSSettings).colorEnhance_color_factor.ToString();
+            this.ce_color_simple.Value = (profile_manager.Settings as BnSSettings).colorEnhance_color_simple;
+            this.ce_color_simple_label.Text = (profile_manager.Settings as BnSSettings).colorEnhance_color_simple.ToString();
+            this.ce_color_gamma.Value = (profile_manager.Settings as BnSSettings).colorEnhance_color_gamma;
+            this.ce_color_gamma_label.Text = (profile_manager.Settings as BnSSettings).colorEnhance_color_gamma.ToString();
         }
 
         private void patch_32bit_button_Click(object sender, RoutedEventArgs e)
@@ -80,12 +85,41 @@ namespace Aurora.Profiles.Blade_and_Soul
             }
         }
 
+        private void ce_mode_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (IsLoaded)
+            {
+                (profile_manager.Settings as BnSSettings).colorEnhance_Mode = (int)this.ce_mode.SelectedIndex;
+                profile_manager.SaveProfiles();
+            }
+        }
+
         private void ce_color_factor_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             if (IsLoaded)
             {
                 (profile_manager.Settings as BnSSettings).colorEnhance_color_factor = (int)this.ce_color_factor.Value;
                 this.ce_color_factor_label.Text = ((int)this.ce_color_factor.Value).ToString();
+                profile_manager.SaveProfiles();
+            }
+        }
+
+        private void ce_color_simple_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            if (IsLoaded)
+            {
+                (profile_manager.Settings as BnSSettings).colorEnhance_color_simple = (float)this.ce_color_simple.Value;
+                this.ce_color_simple_label.Text = ((float)this.ce_color_simple.Value).ToString();
+                profile_manager.SaveProfiles();
+            }
+        }
+
+        private void ce_color_gamma_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            if (IsLoaded)
+            {
+                (profile_manager.Settings as BnSSettings).colorEnhance_color_gamma = (float)this.ce_color_gamma.Value;
+                this.ce_color_gamma_label.Text = ((float)this.ce_color_gamma.Value).ToString();
                 profile_manager.SaveProfiles();
             }
         }

--- a/Project-Aurora/Profiles/Blade and Soul/Control_BnS.xaml.cs
+++ b/Project-Aurora/Profiles/Blade and Soul/Control_BnS.xaml.cs
@@ -40,10 +40,10 @@ namespace Aurora.Profiles.Blade_and_Soul
             this.ce_mode.SelectedIndex = (profile_manager.Settings as BnSSettings).colorEnhance_Mode;
             this.ce_color_factor.Value = (profile_manager.Settings as BnSSettings).colorEnhance_color_factor;
             this.ce_color_factor_label.Text = (profile_manager.Settings as BnSSettings).colorEnhance_color_factor.ToString();
-            this.ce_color_simple.Value = (profile_manager.Settings as BnSSettings).colorEnhance_color_simple;
-            this.ce_color_simple_label.Text = (profile_manager.Settings as BnSSettings).colorEnhance_color_simple.ToString();
-            this.ce_color_gamma.Value = (profile_manager.Settings as BnSSettings).colorEnhance_color_gamma;
-            this.ce_color_gamma_label.Text = (profile_manager.Settings as BnSSettings).colorEnhance_color_gamma.ToString();
+            this.ce_color_hsv_sine.Value = (profile_manager.Settings as BnSSettings).colorEnhance_color_hsv_sine;
+            this.ce_color_hsv_sine_label.Text = (profile_manager.Settings as BnSSettings).colorEnhance_color_hsv_sine.ToString();
+            this.ce_color_hsv_gamma.Value = (profile_manager.Settings as BnSSettings).colorEnhance_color_hsv_gamma;
+            this.ce_color_hsv_gamma_label.Text = (profile_manager.Settings as BnSSettings).colorEnhance_color_hsv_gamma.ToString();
         }
 
         private void patch_32bit_button_Click(object sender, RoutedEventArgs e)
@@ -104,22 +104,22 @@ namespace Aurora.Profiles.Blade_and_Soul
             }
         }
 
-        private void ce_color_simple_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        private void ce_color_hsv_sine_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             if (IsLoaded)
             {
-                (profile_manager.Settings as BnSSettings).colorEnhance_color_simple = (float)this.ce_color_simple.Value;
-                this.ce_color_simple_label.Text = ((float)this.ce_color_simple.Value).ToString();
+                (profile_manager.Settings as BnSSettings).colorEnhance_color_hsv_sine = (float)this.ce_color_hsv_sine.Value;
+                this.ce_color_hsv_sine_label.Text = ((float)this.ce_color_hsv_sine.Value).ToString();
                 profile_manager.SaveProfiles();
             }
         }
 
-        private void ce_color_gamma_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        private void ce_color_hsv_gamma_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             if (IsLoaded)
             {
-                (profile_manager.Settings as BnSSettings).colorEnhance_color_gamma = (float)this.ce_color_gamma.Value;
-                this.ce_color_gamma_label.Text = ((float)this.ce_color_gamma.Value).ToString();
+                (profile_manager.Settings as BnSSettings).colorEnhance_color_hsv_gamma = (float)this.ce_color_hsv_gamma.Value;
+                this.ce_color_hsv_gamma_label.Text = ((float)this.ce_color_hsv_gamma.Value).ToString();
                 profile_manager.SaveProfiles();
             }
         }

--- a/Project-Aurora/Profiles/Blade and Soul/GameEvent_BnS.cs
+++ b/Project-Aurora/Profiles/Blade and Soul/GameEvent_BnS.cs
@@ -19,7 +19,10 @@ namespace Aurora.Profiles.Blade_and_Soul
         protected override void UpdateExtraLights(Queue<EffectLayer> layers)
         {
             this.colorEnhance_Enabled = (this.Profile.Settings as BnSSettings).colorEnhance_Enabled;
+            this.colorEnhance_Mode = (this.Profile.Settings as BnSSettings).colorEnhance_Mode;
             this.colorEnhance_color_factor = (this.Profile.Settings as BnSSettings).colorEnhance_color_factor;
+            this.colorEnhance_color_hsv_sine = (this.Profile.Settings as BnSSettings).colorEnhance_color_hsv_sine;
+            this.colorEnhance_color_hsv_gamma = (this.Profile.Settings as BnSSettings).colorEnhance_color_hsv_gamma;
         }
     }
 }

--- a/Project-Aurora/Profiles/Blade and Soul/GameEvent_BnS.cs
+++ b/Project-Aurora/Profiles/Blade and Soul/GameEvent_BnS.cs
@@ -19,7 +19,6 @@ namespace Aurora.Profiles.Blade_and_Soul
         protected override void UpdateExtraLights(Queue<EffectLayer> layers)
         {
             this.colorEnhance_Enabled = (this.Profile.Settings as BnSSettings).colorEnhance_Enabled;
-            this.colorEnhance_initial_factor = (this.Profile.Settings as BnSSettings).colorEnhance_initial_factor;
             this.colorEnhance_color_factor = (this.Profile.Settings as BnSSettings).colorEnhance_color_factor;
         }
     }

--- a/Project-Aurora/Profiles/Overwatch/Control_Overwatch.xaml
+++ b/Project-Aurora/Profiles/Overwatch/Control_Overwatch.xaml
@@ -21,7 +21,7 @@
     </UserControl.Resources>
 
     <Grid>
-        <TabControl Margin="-10,0,10,0">
+        <TabControl>
             <TabItem Header="Overview for Overwatch">
                 <Grid>
                     <StackPanel>
@@ -39,18 +39,18 @@
                     <TextBlock Text="Color Enhancing Mode:" Margin="20,33,0,0" VerticalAlignment="Top" HorizontalAlignment="Left"/>
                     <ComboBox x:Name="ce_mode" HorizontalAlignment="Left" Margin="149,30,0,0" VerticalAlignment="Top" Width="120" SelectedIndex="0" SelectionChanged="ce_mode_SelectionChanged">
                         <ComboBoxItem Content="Linear"/>
-                        <ComboBoxItem Content="Simple" ToolTip="Simple multiplication with color restribution."/>
-                        <ComboBoxItem Content="Gamma" ToolTip="Using normal image gamma correction. It affects "/>
+                        <ComboBoxItem Content="HSV"/>
                     </ComboBox>
                     <TextBlock HorizontalAlignment="Left" Margin="20,57,0,0" TextWrapping="Wrap" Text="Color Factor:" VerticalAlignment="Top"/>
-                    <Slider x:Name="ce_color_factor" HorizontalAlignment="Left" Margin="101,57,0,0" VerticalAlignment="Top" Width="200" Minimum="1" Maximum="255" Value="90" ValueChanged="ce_color_factor_ValueChanged"/>
-                    <TextBlock x:Name="ce_color_factor_label" HorizontalAlignment="Left" Margin="306,57,0,0" TextWrapping="Wrap" Text="255" VerticalAlignment="Top"/>
-                    <TextBlock HorizontalAlignment="Left" Margin="20,80,0,0" TextWrapping="Wrap" Text="Simple Factor:" VerticalAlignment="Top"/>
-                    <Slider x:Name="ce_color_simple" HorizontalAlignment="Left" Margin="101,80,0,0" VerticalAlignment="Top" Width="200" Minimum="1.0" Maximum="2" Value="1.2" ValueChanged="ce_color_simple_ValueChanged" IsSnapToTickEnabled="True" TickFrequency="0.05"/>
-                    <TextBlock x:Name="ce_color_simple_label" HorizontalAlignment="Left" Margin="306,80,0,0" TextWrapping="Wrap" Text="2.0" VerticalAlignment="Top"/>
-                    <TextBlock HorizontalAlignment="Left" Margin="20,103,0,0" TextWrapping="Wrap" Text="Gamma Value:" VerticalAlignment="Top"/>
-                    <Slider x:Name="ce_color_gamma" HorizontalAlignment="Left" Margin="101,103,0,0" VerticalAlignment="Top" Width="200" Minimum="1.0" Maximum="4.0" Value="2.0" ValueChanged="ce_color_gamma_ValueChanged" IsSnapToTickEnabled="True" TickFrequency="0.1"/>
-                    <TextBlock x:Name="ce_color_gamma_label" HorizontalAlignment="Left" Margin="306,103,0,0" TextWrapping="Wrap" Text="4.0" VerticalAlignment="Top"/>
+                    <Slider x:Name="ce_color_factor" HorizontalAlignment="Left" Margin="126,57,0,0" VerticalAlignment="Top" Width="200" Minimum="1" Maximum="255" Value="90" ValueChanged="ce_color_factor_ValueChanged"/>
+                    <TextBlock x:Name="ce_color_factor_label" HorizontalAlignment="Left" Margin="331,57,0,0" TextWrapping="Wrap" Text="255" VerticalAlignment="Top"/>
+                    <TextBlock HorizontalAlignment="Left" Margin="20,80,0,0" TextWrapping="Wrap" Text="HSV Sine Factor:" VerticalAlignment="Top" ToolTip="Changes the factor on how much the sine applies to the Formula, which makes darker colors brighter and bright colors darker. Higher values have a greater impact."/>
+                    <Slider x:Name="ce_color_hsv_sine" HorizontalAlignment="Left" Margin="126,80,0,0" VerticalAlignment="Top" Width="200" Minimum="0.0" Maximum="0.16" Value="0.1" ValueChanged="ce_color_hsv_sine_ValueChanged" IsSnapToTickEnabled="True" TickFrequency="0.02"/>
+                    <TextBlock x:Name="ce_color_hsv_sine_label" HorizontalAlignment="Left" Margin="335,80,0,0" TextWrapping="Wrap" Text="0.1" VerticalAlignment="Top"/>
+                    <TextBlock HorizontalAlignment="Left" Margin="20,103,0,0" TextWrapping="Wrap" Text="HSV Gamma Value:" VerticalAlignment="Top" ToolTip="Changes the factor for overall stronger colors. It cancels out the effect of the option above in the upper half of the brightness spectrum."/>
+                    <Slider x:Name="ce_color_hsv_gamma" HorizontalAlignment="Left" Margin="126,103,0,0" VerticalAlignment="Top" Width="200" Minimum="1.0" Maximum="4.0" Value="1.5" ValueChanged="ce_color_hsv_gamma_ValueChanged" IsSnapToTickEnabled="True" TickFrequency="0.05"/>
+                    <TextBlock x:Name="ce_color_hsv_gamma_label" HorizontalAlignment="Left" Margin="335,103,0,0" TextWrapping="Wrap" Text="1.5" VerticalAlignment="Top"/>
+                    <TextBlock TextWrapping="Wrap" Text="HSV is an advanced algorithm to make to colors look brighter. It uses the following Formula to calculate" Margin="37,143,0,0" HorizontalAlignment="Left" Width="190" VerticalAlignment="Top"/>
                 </Grid>
             </TabItem>
         </TabControl>

--- a/Project-Aurora/Profiles/Overwatch/Control_Overwatch.xaml
+++ b/Project-Aurora/Profiles/Overwatch/Control_Overwatch.xaml
@@ -21,7 +21,7 @@
     </UserControl.Resources>
 
     <Grid>
-        <TabControl>
+        <TabControl Margin="-10,0,10,0">
             <TabItem Header="Overview for Overwatch">
                 <Grid>
                     <StackPanel>
@@ -35,10 +35,22 @@
             </TabItem>
             <TabItem Header="Color Enhancing">
                 <Grid>
-                    <CheckBox x:Name="ow_ce_enabled" Content="Enable Color Enhancing" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" Checked="ow_ce_enabled_Checked" Unchecked="ow_ce_enabled_Checked"/>
-                    <TextBlock HorizontalAlignment="Left" Margin="10,30,0,0" TextWrapping="Wrap" Text="Color Factor:" VerticalAlignment="Top"/>
-                    <Slider x:Name="ow_ce_color_factor" HorizontalAlignment="Left" Margin="82,30,0,0" VerticalAlignment="Top" Width="200" Minimum="1" Maximum="255" Value="90" ValueChanged="ow_ce_color_factor_ValueChanged"/>
-                    <TextBlock x:Name="ow_ce_color_factor_label" HorizontalAlignment="Left" Margin="287,33,0,0" TextWrapping="Wrap" Text="255" VerticalAlignment="Top"/>
+                    <CheckBox x:Name="ce_enabled" Content="Enable Color Enhancing" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" Checked="ce_enabled_Checked" Unchecked="ce_enabled_Checked"/>
+                    <TextBlock Text="Color Enhancing Mode:" Margin="20,33,0,0" VerticalAlignment="Top" HorizontalAlignment="Left"/>
+                    <ComboBox x:Name="ce_mode" HorizontalAlignment="Left" Margin="149,30,0,0" VerticalAlignment="Top" Width="120" SelectedIndex="0" SelectionChanged="ce_mode_SelectionChanged">
+                        <ComboBoxItem Content="Linear"/>
+                        <ComboBoxItem Content="Simple" ToolTip="Simple multiplication with color restribution."/>
+                        <ComboBoxItem Content="Gamma" ToolTip="Using normal image gamma correction. It affects "/>
+                    </ComboBox>
+                    <TextBlock HorizontalAlignment="Left" Margin="20,57,0,0" TextWrapping="Wrap" Text="Color Factor:" VerticalAlignment="Top"/>
+                    <Slider x:Name="ce_color_factor" HorizontalAlignment="Left" Margin="101,57,0,0" VerticalAlignment="Top" Width="200" Minimum="1" Maximum="255" Value="90" ValueChanged="ce_color_factor_ValueChanged"/>
+                    <TextBlock x:Name="ce_color_factor_label" HorizontalAlignment="Left" Margin="306,57,0,0" TextWrapping="Wrap" Text="255" VerticalAlignment="Top"/>
+                    <TextBlock HorizontalAlignment="Left" Margin="20,80,0,0" TextWrapping="Wrap" Text="Simple Factor:" VerticalAlignment="Top"/>
+                    <Slider x:Name="ce_color_simple" HorizontalAlignment="Left" Margin="101,80,0,0" VerticalAlignment="Top" Width="200" Minimum="1.0" Maximum="2" Value="1.2" ValueChanged="ce_color_simple_ValueChanged" IsSnapToTickEnabled="True" TickFrequency="0.05"/>
+                    <TextBlock x:Name="ce_color_simple_label" HorizontalAlignment="Left" Margin="306,80,0,0" TextWrapping="Wrap" Text="2.0" VerticalAlignment="Top"/>
+                    <TextBlock HorizontalAlignment="Left" Margin="20,103,0,0" TextWrapping="Wrap" Text="Gamma Value:" VerticalAlignment="Top"/>
+                    <Slider x:Name="ce_color_gamma" HorizontalAlignment="Left" Margin="101,103,0,0" VerticalAlignment="Top" Width="200" Minimum="1.0" Maximum="4.0" Value="2.0" ValueChanged="ce_color_gamma_ValueChanged" IsSnapToTickEnabled="True" TickFrequency="0.1"/>
+                    <TextBlock x:Name="ce_color_gamma_label" HorizontalAlignment="Left" Margin="306,103,0,0" TextWrapping="Wrap" Text="4.0" VerticalAlignment="Top"/>
                 </Grid>
             </TabItem>
         </TabControl>

--- a/Project-Aurora/Profiles/Overwatch/Control_Overwatch.xaml.cs
+++ b/Project-Aurora/Profiles/Overwatch/Control_Overwatch.xaml.cs
@@ -31,10 +31,10 @@ namespace Aurora.Profiles.Overwatch
             this.ce_mode.SelectedIndex = (profile_manager.Settings as OverwatchSettings).colorEnhance_Mode;
             this.ce_color_factor.Value = (profile_manager.Settings as OverwatchSettings).colorEnhance_color_factor;
             this.ce_color_factor_label.Text = (profile_manager.Settings as OverwatchSettings).colorEnhance_color_factor.ToString();
-            this.ce_color_simple.Value = (profile_manager.Settings as OverwatchSettings).colorEnhance_color_simple;
-            this.ce_color_simple_label.Text = (profile_manager.Settings as OverwatchSettings).colorEnhance_color_simple.ToString();
-            this.ce_color_gamma.Value = (profile_manager.Settings as OverwatchSettings).colorEnhance_color_gamma;
-            this.ce_color_gamma_label.Text = (profile_manager.Settings as OverwatchSettings).colorEnhance_color_gamma.ToString();
+            this.ce_color_hsv_sine.Value = (profile_manager.Settings as OverwatchSettings).colorEnhance_color_hsv_sine;
+            this.ce_color_hsv_sine_label.Text = (profile_manager.Settings as OverwatchSettings).colorEnhance_color_hsv_sine.ToString();
+            this.ce_color_hsv_gamma.Value = (profile_manager.Settings as OverwatchSettings).colorEnhance_color_hsv_gamma;
+            this.ce_color_hsv_gamma_label.Text = (profile_manager.Settings as OverwatchSettings).colorEnhance_color_hsv_gamma.ToString();
         }
 
         private void patch_button_Click(object sender, RoutedEventArgs e)
@@ -103,22 +103,22 @@ namespace Aurora.Profiles.Overwatch
             }
         }
         
-        private void ce_color_simple_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        private void ce_color_hsv_sine_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             if (IsLoaded)
             {
-                (profile_manager.Settings as OverwatchSettings).colorEnhance_color_simple = (float)this.ce_color_simple.Value;
-                this.ce_color_simple_label.Text = ((float)this.ce_color_simple.Value).ToString();
+                (profile_manager.Settings as OverwatchSettings).colorEnhance_color_hsv_sine = (float)this.ce_color_hsv_sine.Value;
+                this.ce_color_hsv_sine_label.Text = ((float)this.ce_color_hsv_sine.Value).ToString();
                 profile_manager.SaveProfiles();
             }
         }
 
-        private void ce_color_gamma_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        private void ce_color_hsv_gamma_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             if (IsLoaded)
             {
-                (profile_manager.Settings as OverwatchSettings).colorEnhance_color_gamma = (float)this.ce_color_gamma.Value;
-                this.ce_color_gamma_label.Text = ((float)this.ce_color_gamma.Value).ToString();
+                (profile_manager.Settings as OverwatchSettings).colorEnhance_color_hsv_gamma = (float)this.ce_color_hsv_gamma.Value;
+                this.ce_color_hsv_gamma_label.Text = ((float)this.ce_color_hsv_gamma.Value).ToString();
                 profile_manager.SaveProfiles();
             }
         }

--- a/Project-Aurora/Profiles/Overwatch/Control_Overwatch.xaml.cs
+++ b/Project-Aurora/Profiles/Overwatch/Control_Overwatch.xaml.cs
@@ -27,9 +27,14 @@ namespace Aurora.Profiles.Overwatch
             this.scriptmanager.ProfileManager = profile_manager;
 
             this.game_enabled.IsChecked = (profile_manager.Settings as OverwatchSettings).isEnabled;
-            this.ow_ce_enabled.IsChecked = (profile_manager.Settings as OverwatchSettings).colorEnhance_Enabled;
-            this.ow_ce_color_factor.Value = (profile_manager.Settings as OverwatchSettings).colorEnhance_color_factor;
-            this.ow_ce_color_factor_label.Text = (profile_manager.Settings as OverwatchSettings).colorEnhance_color_factor.ToString();
+            this.ce_enabled.IsChecked = (profile_manager.Settings as OverwatchSettings).colorEnhance_Enabled;
+            this.ce_mode.SelectedIndex = (profile_manager.Settings as OverwatchSettings).colorEnhance_Mode;
+            this.ce_color_factor.Value = (profile_manager.Settings as OverwatchSettings).colorEnhance_color_factor;
+            this.ce_color_factor_label.Text = (profile_manager.Settings as OverwatchSettings).colorEnhance_color_factor.ToString();
+            this.ce_color_simple.Value = (profile_manager.Settings as OverwatchSettings).colorEnhance_color_simple;
+            this.ce_color_simple_label.Text = (profile_manager.Settings as OverwatchSettings).colorEnhance_color_simple.ToString();
+            this.ce_color_gamma.Value = (profile_manager.Settings as OverwatchSettings).colorEnhance_color_gamma;
+            this.ce_color_gamma_label.Text = (profile_manager.Settings as OverwatchSettings).colorEnhance_color_gamma.ToString();
         }
 
         private void patch_button_Click(object sender, RoutedEventArgs e)
@@ -70,21 +75,50 @@ namespace Aurora.Profiles.Overwatch
             }
         }
 
-        private void ow_ce_enabled_Checked(object sender, RoutedEventArgs e)
+        private void ce_enabled_Checked(object sender, RoutedEventArgs e)
         {
             if (IsLoaded)
             {
-                (profile_manager.Settings as OverwatchSettings).colorEnhance_Enabled = (this.ow_ce_enabled.IsChecked.HasValue) ? this.ow_ce_enabled.IsChecked.Value : false;
+                (profile_manager.Settings as OverwatchSettings).colorEnhance_Enabled = (this.ce_enabled.IsChecked.HasValue) ? this.ce_enabled.IsChecked.Value : false;
                 profile_manager.SaveProfiles();
             }
         }
 
-        private void ow_ce_color_factor_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        private void ce_mode_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if (IsLoaded)
             {
-                (profile_manager.Settings as OverwatchSettings).colorEnhance_color_factor = (int)this.ow_ce_color_factor.Value;
-                this.ow_ce_color_factor_label.Text = ((int)this.ow_ce_color_factor.Value).ToString();
+                (profile_manager.Settings as OverwatchSettings).colorEnhance_Mode = (int)this.ce_mode.SelectedIndex;
+                profile_manager.SaveProfiles();
+            }
+        }
+
+        private void ce_color_factor_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            if (IsLoaded)
+            {
+                (profile_manager.Settings as OverwatchSettings).colorEnhance_color_factor = (int)this.ce_color_factor.Value;
+                this.ce_color_factor_label.Text = ((int)this.ce_color_factor.Value).ToString();
+                profile_manager.SaveProfiles();
+            }
+        }
+        
+        private void ce_color_simple_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            if (IsLoaded)
+            {
+                (profile_manager.Settings as OverwatchSettings).colorEnhance_color_simple = (float)this.ce_color_simple.Value;
+                this.ce_color_simple_label.Text = ((float)this.ce_color_simple.Value).ToString();
+                profile_manager.SaveProfiles();
+            }
+        }
+
+        private void ce_color_gamma_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            if (IsLoaded)
+            {
+                (profile_manager.Settings as OverwatchSettings).colorEnhance_color_gamma = (float)this.ce_color_gamma.Value;
+                this.ce_color_gamma_label.Text = ((float)this.ce_color_gamma.Value).ToString();
                 profile_manager.SaveProfiles();
             }
         }

--- a/Project-Aurora/Profiles/Overwatch/GameEvent_Overwatch.cs
+++ b/Project-Aurora/Profiles/Overwatch/GameEvent_Overwatch.cs
@@ -23,8 +23,8 @@ namespace Aurora.Profiles.Overwatch
             this.colorEnhance_Enabled = (this.Profile.Settings as OverwatchSettings).colorEnhance_Enabled;
             this.colorEnhance_Mode = (this.Profile.Settings as OverwatchSettings).colorEnhance_Mode;
             this.colorEnhance_color_factor = (this.Profile.Settings as OverwatchSettings).colorEnhance_color_factor;
-            this.colorEnhance_color_simple = (this.Profile.Settings as OverwatchSettings).colorEnhance_color_simple;
-            this.colorEnhance_color_gamma = (this.Profile.Settings as OverwatchSettings).colorEnhance_color_gamma;
+            this.colorEnhance_color_hsv_sine = (this.Profile.Settings as OverwatchSettings).colorEnhance_color_hsv_sine;
+            this.colorEnhance_color_hsv_gamma = (this.Profile.Settings as OverwatchSettings).colorEnhance_color_hsv_gamma;
         }
     }
 }

--- a/Project-Aurora/Profiles/Overwatch/GameEvent_Overwatch.cs
+++ b/Project-Aurora/Profiles/Overwatch/GameEvent_Overwatch.cs
@@ -21,8 +21,10 @@ namespace Aurora.Profiles.Overwatch
         protected override void UpdateExtraLights(Queue<EffectLayer> layers)
         {
             this.colorEnhance_Enabled = (this.Profile.Settings as OverwatchSettings).colorEnhance_Enabled;
-            this.colorEnhance_initial_factor = (this.Profile.Settings as OverwatchSettings).colorEnhance_initial_factor;
+            this.colorEnhance_Mode = (this.Profile.Settings as OverwatchSettings).colorEnhance_Mode;
             this.colorEnhance_color_factor = (this.Profile.Settings as OverwatchSettings).colorEnhance_color_factor;
+            this.colorEnhance_color_simple = (this.Profile.Settings as OverwatchSettings).colorEnhance_color_simple;
+            this.colorEnhance_color_gamma = (this.Profile.Settings as OverwatchSettings).colorEnhance_color_gamma;
         }
     }
 }

--- a/Project-Aurora/Profiles/Overwatch/OverwatchSettings.cs
+++ b/Project-Aurora/Profiles/Overwatch/OverwatchSettings.cs
@@ -9,8 +9,8 @@ namespace Aurora.Profiles.Overwatch
         public bool colorEnhance_Enabled;
         public int colorEnhance_Mode;
         public int colorEnhance_color_factor;
-        public float colorEnhance_color_simple;
-        public float colorEnhance_color_gamma;
+        public float colorEnhance_color_hsv_sine;
+        public float colorEnhance_color_hsv_gamma;
 
         public OverwatchSettings()
         {
@@ -22,8 +22,8 @@ namespace Aurora.Profiles.Overwatch
             colorEnhance_Enabled = true;
             colorEnhance_Mode = 0;
             colorEnhance_color_factor = 90;
-            colorEnhance_color_simple = 1.2f;
-            colorEnhance_color_gamma = 2.5f;
+            colorEnhance_color_hsv_sine = 0.1f;
+            colorEnhance_color_hsv_gamma = 2.5f;
         }
     }
 }

--- a/Project-Aurora/Profiles/Overwatch/OverwatchSettings.cs
+++ b/Project-Aurora/Profiles/Overwatch/OverwatchSettings.cs
@@ -7,8 +7,10 @@ namespace Aurora.Profiles.Overwatch
         //Effects
         //// Color Enhancing
         public bool colorEnhance_Enabled;
-        public float colorEnhance_initial_factor;
+        public int colorEnhance_Mode;
         public int colorEnhance_color_factor;
+        public float colorEnhance_color_simple;
+        public float colorEnhance_color_gamma;
 
         public OverwatchSettings()
         {
@@ -18,8 +20,10 @@ namespace Aurora.Profiles.Overwatch
             //Effects
             //// Color Enhancing
             colorEnhance_Enabled = true;
-            colorEnhance_initial_factor = 3.0f;
+            colorEnhance_Mode = 0;
             colorEnhance_color_factor = 90;
+            colorEnhance_color_simple = 1.2f;
+            colorEnhance_color_gamma = 2.5f;
         }
     }
 }

--- a/Project-Aurora/Profiles/Worms_WMD/Control_WormsWMD.xaml
+++ b/Project-Aurora/Profiles/Worms_WMD/Control_WormsWMD.xaml
@@ -40,9 +40,21 @@
             <TabItem Header="Color Enhancing">
                 <Grid>
                     <CheckBox x:Name="ce_enabled" Content="Enable Color Enhancing" HorizontalAlignment="Left" Margin="10,10,0,0" VerticalAlignment="Top" Checked="ce_enabled_Checked" Unchecked="ce_enabled_Checked"/>
-                    <TextBlock HorizontalAlignment="Left" Margin="10,30,0,0" TextWrapping="Wrap" Text="Color Factor:" VerticalAlignment="Top"/>
-                    <Slider x:Name="ce_color_factor" HorizontalAlignment="Left" Margin="82,30,0,0" VerticalAlignment="Top" Width="200" Minimum="1" Maximum="255" Value="90" ValueChanged="ce_color_factor_ValueChanged"/>
-                    <TextBlock x:Name="ce_color_factor_label" HorizontalAlignment="Left" Margin="287,33,0,0" TextWrapping="Wrap" Text="255" VerticalAlignment="Top"/>
+                    <TextBlock Text="Color Enhancing Mode:" Margin="20,33,0,0" VerticalAlignment="Top" HorizontalAlignment="Left"/>
+                    <ComboBox x:Name="ce_mode" HorizontalAlignment="Left" Margin="149,30,0,0" VerticalAlignment="Top" Width="120" SelectedIndex="0" SelectionChanged="ce_mode_SelectionChanged">
+                        <ComboBoxItem Content="Linear"/>
+                        <ComboBoxItem Content="Simple" ToolTip="Simple multiplication with color restribution."/>
+                        <ComboBoxItem Content="Gamma" ToolTip="Using normal image gamma correction. It affects "/>
+                    </ComboBox>
+                    <TextBlock HorizontalAlignment="Left" Margin="20,57,0,0" TextWrapping="Wrap" Text="Color Factor:" VerticalAlignment="Top"/>
+                    <Slider x:Name="ce_color_factor" HorizontalAlignment="Left" Margin="101,57,0,0" VerticalAlignment="Top" Width="200" Minimum="1" Maximum="255" Value="90" ValueChanged="ce_color_factor_ValueChanged"/>
+                    <TextBlock x:Name="ce_color_factor_label" HorizontalAlignment="Left" Margin="306,57,0,0" TextWrapping="Wrap" Text="255" VerticalAlignment="Top"/>
+                    <TextBlock HorizontalAlignment="Left" Margin="20,80,0,0" TextWrapping="Wrap" Text="Simple Factor:" VerticalAlignment="Top"/>
+                    <Slider x:Name="ce_color_simple" HorizontalAlignment="Left" Margin="101,80,0,0" VerticalAlignment="Top" Width="200" Minimum="1.0" Maximum="2" Value="1.2" ValueChanged="ce_color_simple_ValueChanged" IsSnapToTickEnabled="True" TickFrequency="0.05"/>
+                    <TextBlock x:Name="ce_color_simple_label" HorizontalAlignment="Left" Margin="306,80,0,0" TextWrapping="Wrap" Text="2.0" VerticalAlignment="Top"/>
+                    <TextBlock HorizontalAlignment="Left" Margin="20,103,0,0" TextWrapping="Wrap" Text="Gamma Value:" VerticalAlignment="Top"/>
+                    <Slider x:Name="ce_color_gamma" HorizontalAlignment="Left" Margin="101,103,0,0" VerticalAlignment="Top" Width="200" Minimum="1.0" Maximum="4.0" Value="2.0" ValueChanged="ce_color_gamma_ValueChanged" IsSnapToTickEnabled="True" TickFrequency="0.1"/>
+                    <TextBlock x:Name="ce_color_gamma_label" HorizontalAlignment="Left" Margin="306,103,0,0" TextWrapping="Wrap" Text="4.0" VerticalAlignment="Top"/>
                 </Grid>
             </TabItem>
         </TabControl>

--- a/Project-Aurora/Profiles/Worms_WMD/Control_WormsWMD.xaml
+++ b/Project-Aurora/Profiles/Worms_WMD/Control_WormsWMD.xaml
@@ -43,18 +43,18 @@
                     <TextBlock Text="Color Enhancing Mode:" Margin="20,33,0,0" VerticalAlignment="Top" HorizontalAlignment="Left"/>
                     <ComboBox x:Name="ce_mode" HorizontalAlignment="Left" Margin="149,30,0,0" VerticalAlignment="Top" Width="120" SelectedIndex="0" SelectionChanged="ce_mode_SelectionChanged">
                         <ComboBoxItem Content="Linear"/>
-                        <ComboBoxItem Content="Simple" ToolTip="Simple multiplication with color restribution."/>
-                        <ComboBoxItem Content="Gamma" ToolTip="Using normal image gamma correction. It affects "/>
+                        <ComboBoxItem Content="HSV"/>
                     </ComboBox>
                     <TextBlock HorizontalAlignment="Left" Margin="20,57,0,0" TextWrapping="Wrap" Text="Color Factor:" VerticalAlignment="Top"/>
-                    <Slider x:Name="ce_color_factor" HorizontalAlignment="Left" Margin="101,57,0,0" VerticalAlignment="Top" Width="200" Minimum="1" Maximum="255" Value="90" ValueChanged="ce_color_factor_ValueChanged"/>
-                    <TextBlock x:Name="ce_color_factor_label" HorizontalAlignment="Left" Margin="306,57,0,0" TextWrapping="Wrap" Text="255" VerticalAlignment="Top"/>
-                    <TextBlock HorizontalAlignment="Left" Margin="20,80,0,0" TextWrapping="Wrap" Text="Simple Factor:" VerticalAlignment="Top"/>
-                    <Slider x:Name="ce_color_simple" HorizontalAlignment="Left" Margin="101,80,0,0" VerticalAlignment="Top" Width="200" Minimum="1.0" Maximum="2" Value="1.2" ValueChanged="ce_color_simple_ValueChanged" IsSnapToTickEnabled="True" TickFrequency="0.05"/>
-                    <TextBlock x:Name="ce_color_simple_label" HorizontalAlignment="Left" Margin="306,80,0,0" TextWrapping="Wrap" Text="2.0" VerticalAlignment="Top"/>
-                    <TextBlock HorizontalAlignment="Left" Margin="20,103,0,0" TextWrapping="Wrap" Text="Gamma Value:" VerticalAlignment="Top"/>
-                    <Slider x:Name="ce_color_gamma" HorizontalAlignment="Left" Margin="101,103,0,0" VerticalAlignment="Top" Width="200" Minimum="1.0" Maximum="4.0" Value="2.0" ValueChanged="ce_color_gamma_ValueChanged" IsSnapToTickEnabled="True" TickFrequency="0.1"/>
-                    <TextBlock x:Name="ce_color_gamma_label" HorizontalAlignment="Left" Margin="306,103,0,0" TextWrapping="Wrap" Text="4.0" VerticalAlignment="Top"/>
+                    <Slider x:Name="ce_color_factor" HorizontalAlignment="Left" Margin="126,57,0,0" VerticalAlignment="Top" Width="200" Minimum="1" Maximum="255" Value="90" ValueChanged="ce_color_factor_ValueChanged"/>
+                    <TextBlock x:Name="ce_color_factor_label" HorizontalAlignment="Left" Margin="331,57,0,0" TextWrapping="Wrap" Text="255" VerticalAlignment="Top"/>
+                    <TextBlock HorizontalAlignment="Left" Margin="20,80,0,0" TextWrapping="Wrap" Text="HSV Sine Factor:" VerticalAlignment="Top" ToolTip="Changes the factor on how much the sine applies to the Formula, which makes darker colors brighter and bright colors darker. Higher values have a greater impact."/>
+                    <Slider x:Name="ce_color_hsv_sine" HorizontalAlignment="Left" Margin="126,80,0,0" VerticalAlignment="Top" Width="200" Minimum="0.0" Maximum="0.16" Value="0.1" ValueChanged="ce_color_hsv_sine_ValueChanged" IsSnapToTickEnabled="True" TickFrequency="0.02"/>
+                    <TextBlock x:Name="ce_color_hsv_sine_label" HorizontalAlignment="Left" Margin="335,80,0,0" TextWrapping="Wrap" Text="0.1" VerticalAlignment="Top"/>
+                    <TextBlock HorizontalAlignment="Left" Margin="20,103,0,0" TextWrapping="Wrap" Text="HSV Gamma Value:" VerticalAlignment="Top" ToolTip="Changes the factor for overall stronger colors. It cancels out the effect of the option above in the upper half of the brightness spectrum."/>
+                    <Slider x:Name="ce_color_hsv_gamma" HorizontalAlignment="Left" Margin="126,103,0,0" VerticalAlignment="Top" Width="200" Minimum="1.0" Maximum="4.0" Value="1.5" ValueChanged="ce_color_hsv_gamma_ValueChanged" IsSnapToTickEnabled="True" TickFrequency="0.05"/>
+                    <TextBlock x:Name="ce_color_hsv_gamma_label" HorizontalAlignment="Left" Margin="335,103,0,0" TextWrapping="Wrap" Text="1.5" VerticalAlignment="Top"/>
+                    <TextBlock TextWrapping="Wrap" Text="HSV is an advanced algorithm to make to colors look brighter. It uses the following Formula to calculate" Margin="37,143,0,0" HorizontalAlignment="Left" Width="190" VerticalAlignment="Top"/>
                 </Grid>
             </TabItem>
         </TabControl>

--- a/Project-Aurora/Profiles/Worms_WMD/Control_WormsWMD.xaml.cs
+++ b/Project-Aurora/Profiles/Worms_WMD/Control_WormsWMD.xaml.cs
@@ -27,10 +27,15 @@ namespace Aurora.Profiles.WormsWMD
             this.profilemanager.ProfileManager = profile_manager;
             this.scriptmanager.ProfileManager = profile_manager;
 
-            this.game_enabled.IsChecked = profile_manager.Settings.isEnabled;
+            this.game_enabled.IsChecked = (profile_manager.Settings as WormsWMDSettings).isEnabled;
             this.ce_enabled.IsChecked = (profile_manager.Settings as WormsWMDSettings).colorEnhance_Enabled;
+            this.ce_mode.SelectedIndex = (profile_manager.Settings as WormsWMDSettings).colorEnhance_Mode;
             this.ce_color_factor.Value = (profile_manager.Settings as WormsWMDSettings).colorEnhance_color_factor;
             this.ce_color_factor_label.Text = (profile_manager.Settings as WormsWMDSettings).colorEnhance_color_factor.ToString();
+            this.ce_color_simple.Value = (profile_manager.Settings as WormsWMDSettings).colorEnhance_color_simple;
+            this.ce_color_simple_label.Text = (profile_manager.Settings as WormsWMDSettings).colorEnhance_color_simple.ToString();
+            this.ce_color_gamma.Value = (profile_manager.Settings as WormsWMDSettings).colorEnhance_color_gamma;
+            this.ce_color_gamma_label.Text = (profile_manager.Settings as WormsWMDSettings).colorEnhance_color_gamma.ToString();
         }
 
         private void patch_button_Click(object sender, RoutedEventArgs e)
@@ -112,6 +117,7 @@ namespace Aurora.Profiles.WormsWMD
             }
         }
 
+
         private void game_enabled_Checked(object sender, RoutedEventArgs e)
         {
             if (IsLoaded)
@@ -130,12 +136,41 @@ namespace Aurora.Profiles.WormsWMD
             }
         }
 
+        private void ce_mode_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (IsLoaded)
+            {
+                (profile_manager.Settings as WormsWMDSettings).colorEnhance_Mode = (int)this.ce_mode.SelectedIndex;
+                profile_manager.SaveProfiles();
+            }
+        }
+
         private void ce_color_factor_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             if (IsLoaded)
             {
                 (profile_manager.Settings as WormsWMDSettings).colorEnhance_color_factor = (int)this.ce_color_factor.Value;
                 this.ce_color_factor_label.Text = ((int)this.ce_color_factor.Value).ToString();
+                profile_manager.SaveProfiles();
+            }
+        }
+
+        private void ce_color_simple_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            if (IsLoaded)
+            {
+                (profile_manager.Settings as WormsWMDSettings).colorEnhance_color_simple = (float)this.ce_color_simple.Value;
+                this.ce_color_simple_label.Text = ((float)this.ce_color_simple.Value).ToString();
+                profile_manager.SaveProfiles();
+            }
+        }
+
+        private void ce_color_gamma_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            if (IsLoaded)
+            {
+                (profile_manager.Settings as WormsWMDSettings).colorEnhance_color_gamma = (float)this.ce_color_gamma.Value;
+                this.ce_color_gamma_label.Text = ((float)this.ce_color_gamma.Value).ToString();
                 profile_manager.SaveProfiles();
             }
         }

--- a/Project-Aurora/Profiles/Worms_WMD/Control_WormsWMD.xaml.cs
+++ b/Project-Aurora/Profiles/Worms_WMD/Control_WormsWMD.xaml.cs
@@ -32,10 +32,10 @@ namespace Aurora.Profiles.WormsWMD
             this.ce_mode.SelectedIndex = (profile_manager.Settings as WormsWMDSettings).colorEnhance_Mode;
             this.ce_color_factor.Value = (profile_manager.Settings as WormsWMDSettings).colorEnhance_color_factor;
             this.ce_color_factor_label.Text = (profile_manager.Settings as WormsWMDSettings).colorEnhance_color_factor.ToString();
-            this.ce_color_simple.Value = (profile_manager.Settings as WormsWMDSettings).colorEnhance_color_simple;
-            this.ce_color_simple_label.Text = (profile_manager.Settings as WormsWMDSettings).colorEnhance_color_simple.ToString();
-            this.ce_color_gamma.Value = (profile_manager.Settings as WormsWMDSettings).colorEnhance_color_gamma;
-            this.ce_color_gamma_label.Text = (profile_manager.Settings as WormsWMDSettings).colorEnhance_color_gamma.ToString();
+            this.ce_color_hsv_sine.Value = (profile_manager.Settings as WormsWMDSettings).colorEnhance_color_hsv_sine;
+            this.ce_color_hsv_sine_label.Text = (profile_manager.Settings as WormsWMDSettings).colorEnhance_color_hsv_sine.ToString();
+            this.ce_color_hsv_gamma.Value = (profile_manager.Settings as WormsWMDSettings).colorEnhance_color_hsv_gamma;
+            this.ce_color_hsv_gamma_label.Text = (profile_manager.Settings as WormsWMDSettings).colorEnhance_color_hsv_gamma.ToString();
         }
 
         private void patch_button_Click(object sender, RoutedEventArgs e)
@@ -155,22 +155,22 @@ namespace Aurora.Profiles.WormsWMD
             }
         }
 
-        private void ce_color_simple_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        private void ce_color_hsv_sine_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             if (IsLoaded)
             {
-                (profile_manager.Settings as WormsWMDSettings).colorEnhance_color_simple = (float)this.ce_color_simple.Value;
-                this.ce_color_simple_label.Text = ((float)this.ce_color_simple.Value).ToString();
+                (profile_manager.Settings as WormsWMDSettings).colorEnhance_color_hsv_sine = (float)this.ce_color_hsv_sine.Value;
+                this.ce_color_hsv_sine_label.Text = ((float)this.ce_color_hsv_sine.Value).ToString();
                 profile_manager.SaveProfiles();
             }
         }
 
-        private void ce_color_gamma_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        private void ce_color_hsv_gamma_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
         {
             if (IsLoaded)
             {
-                (profile_manager.Settings as WormsWMDSettings).colorEnhance_color_gamma = (float)this.ce_color_gamma.Value;
-                this.ce_color_gamma_label.Text = ((float)this.ce_color_gamma.Value).ToString();
+                (profile_manager.Settings as WormsWMDSettings).colorEnhance_color_hsv_gamma = (float)this.ce_color_hsv_gamma.Value;
+                this.ce_color_hsv_gamma_label.Text = ((float)this.ce_color_hsv_gamma.Value).ToString();
                 profile_manager.SaveProfiles();
             }
         }

--- a/Project-Aurora/Profiles/Worms_WMD/GameEvent_WormsWMD.cs
+++ b/Project-Aurora/Profiles/Worms_WMD/GameEvent_WormsWMD.cs
@@ -21,7 +21,6 @@ namespace Aurora.Profiles.WormsWMD
         protected override void UpdateExtraLights(Queue<EffectLayer> layers)
         {
             this.colorEnhance_Enabled = (this.Profile.Settings as WormsWMDSettings).colorEnhance_Enabled;
-            this.colorEnhance_initial_factor = (this.Profile.Settings as WormsWMDSettings).colorEnhance_initial_factor;
             this.colorEnhance_color_factor = (this.Profile.Settings as WormsWMDSettings).colorEnhance_color_factor;
         }
     }

--- a/Project-Aurora/Profiles/Worms_WMD/GameEvent_WormsWMD.cs
+++ b/Project-Aurora/Profiles/Worms_WMD/GameEvent_WormsWMD.cs
@@ -21,7 +21,10 @@ namespace Aurora.Profiles.WormsWMD
         protected override void UpdateExtraLights(Queue<EffectLayer> layers)
         {
             this.colorEnhance_Enabled = (this.Profile.Settings as WormsWMDSettings).colorEnhance_Enabled;
+            this.colorEnhance_Mode = (this.Profile.Settings as WormsWMDSettings).colorEnhance_Mode;
             this.colorEnhance_color_factor = (this.Profile.Settings as WormsWMDSettings).colorEnhance_color_factor;
+            this.colorEnhance_color_hsv_sine = (this.Profile.Settings as WormsWMDSettings).colorEnhance_color_hsv_sine;
+            this.colorEnhance_color_hsv_gamma = (this.Profile.Settings as WormsWMDSettings).colorEnhance_color_hsv_gamma;
         }
     }
 }

--- a/Project-Aurora/Profiles/Worms_WMD/WormsWMDSettings.cs
+++ b/Project-Aurora/Profiles/Worms_WMD/WormsWMDSettings.cs
@@ -7,8 +7,10 @@ namespace Aurora.Profiles.WormsWMD
         //Effects
         //// Color Enhancing
         public bool colorEnhance_Enabled;
-        public float colorEnhance_initial_factor;
+        public int colorEnhance_Mode;
         public int colorEnhance_color_factor;
+        public float colorEnhance_color_simple;
+        public float colorEnhance_color_gamma;
 
         public WormsWMDSettings()
         {
@@ -18,8 +20,10 @@ namespace Aurora.Profiles.WormsWMD
             //Effects
             //// Color Enhancing
             colorEnhance_Enabled = true;
-            colorEnhance_initial_factor = 3.0f;
+            colorEnhance_Mode = 0;
             colorEnhance_color_factor = 90;
+            colorEnhance_color_simple = 1.2f;
+            colorEnhance_color_gamma = 2.5f;
         }
     }
 }

--- a/Project-Aurora/Profiles/Worms_WMD/WormsWMDSettings.cs
+++ b/Project-Aurora/Profiles/Worms_WMD/WormsWMDSettings.cs
@@ -9,8 +9,8 @@ namespace Aurora.Profiles.WormsWMD
         public bool colorEnhance_Enabled;
         public int colorEnhance_Mode;
         public int colorEnhance_color_factor;
-        public float colorEnhance_color_simple;
-        public float colorEnhance_color_gamma;
+        public float colorEnhance_color_hsv_sine;
+        public float colorEnhance_color_hsv_gamma;
 
         public WormsWMDSettings()
         {
@@ -22,8 +22,8 @@ namespace Aurora.Profiles.WormsWMD
             colorEnhance_Enabled = true;
             colorEnhance_Mode = 0;
             colorEnhance_color_factor = 90;
-            colorEnhance_color_simple = 1.2f;
-            colorEnhance_color_gamma = 2.5f;
+            colorEnhance_color_hsv_sine = 0.1f;
+            colorEnhance_color_hsv_gamma = 2.5f;
         }
     }
 }


### PR DESCRIPTION
I have added two additional methods to calculate a brighter color for the Razer Wrapper.

- Simple: A simple multiplication with some overflow detection, and
- Gamma: An implementation of an image gamma correction.

The first one isn't very special, but some people might use it.
The second is pretty good a brighten very dark colors, but makes light colors a bit gray.

In addition, I removed the initial_factor because it wasn't needed.