### PR TITLE
Changed the Process Detection to WINAPI only

### DIFF
--- a/Project-Aurora/GameEventHandler.cs
+++ b/Project-Aurora/GameEventHandler.cs
@@ -144,7 +144,7 @@ namespace Aurora
         [System.Runtime.InteropServices.DllImport("user32.dll", SetLastError = true)]
         static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
 
-		[DllImport("Oleacc.dll")]
+        [DllImport("Oleacc.dll")]
         static extern IntPtr GetProcessHandleFromHwnd(IntPtr whandle);
         [DllImport("psapi.dll")]
         static extern uint GetModuleFileNameEx(IntPtr hProcess, IntPtr hModule, [Out] StringBuilder lpBaseName, [In] [MarshalAs(UnmanagedType.U4)] int nSize);
@@ -159,7 +159,7 @@ namespace Aurora
                 windowHandle = GetForegroundWindow();
                 processhandle = GetProcessHandleFromHwnd(windowHandle);
 
-				StringBuilder sb = new StringBuilder(4048);
+                StringBuilder sb = new StringBuilder(4048);
                 GetModuleFileNameEx(processhandle, zeroHandle, sb, 4048);
                 //Global.logger.LogLine("Process changed: " + sb.ToString(), Logging_Level.Info);
 

--- a/Project-Aurora/GameEventHandler.cs
+++ b/Project-Aurora/GameEventHandler.cs
@@ -144,26 +144,31 @@ namespace Aurora
         [System.Runtime.InteropServices.DllImport("user32.dll", SetLastError = true)]
         static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
 
+		[DllImport("Oleacc.dll")]
+        static extern IntPtr GetProcessHandleFromHwnd(IntPtr whandle);
+        [DllImport("psapi.dll")]
+        static extern uint GetModuleFileNameEx(IntPtr hProcess, IntPtr hModule, [Out] StringBuilder lpBaseName, [In] [MarshalAs(UnmanagedType.U4)] int nSize);
+		
         private string GetActiveWindowsProcessname()
         {
             try
             {
-                IntPtr handle = IntPtr.Zero;
-                handle = GetForegroundWindow();
+                IntPtr windowHandle = IntPtr.Zero;
+                IntPtr processhandle = IntPtr.Zero;
+                IntPtr zeroHandle = IntPtr.Zero;
+                windowHandle = GetForegroundWindow();
+                processhandle = GetProcessHandleFromHwnd(windowHandle);
 
-                uint processId;
-                if (GetWindowThreadProcessId(handle, out processId) > 0)
-                {
-                    return Process.GetProcessById((int)processId).MainModule.FileName;
-                }
-                else
-                {
-                    return "";
-                }
+				StringBuilder sb = new StringBuilder(4048);
+                GetModuleFileNameEx(processhandle, zeroHandle, sb, 4048);
+                //Global.logger.LogLine("Process changed: " + sb.ToString(), Logging_Level.Info);
+
+
+
+               return sb.ToString();
             }
             catch (Exception exc)
             {
-                //Console.WriteLine(exc);
                 return "";
             }
         }


### PR DESCRIPTION
When accessing a x64 Process Module via 
`Process.GetProcessById((int)processId).MainModule`
a Exception was thrown. I changed the detection to only use WINAPI functions, so the architecture won't matter anymore.

**Fixed Issues**
#430

**This pull request proposes the following changes:**
Changed the Process detection in GameEventHandler.cs to WINAPI only.


