### PR TITLE
Changed the Process detection to WINAPI only.

### DIFF
--- a/Project-Aurora/GameEventHandler.cs
+++ b/Project-Aurora/GameEventHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 using System.Collections.Generic;
 using System.Diagnostics;
 //using System.Timers;
@@ -144,26 +145,31 @@ namespace Aurora
         [System.Runtime.InteropServices.DllImport("user32.dll", SetLastError = true)]
         static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
 
+        [DllImport("Oleacc.dll")]
+        static extern IntPtr GetProcessHandleFromHwnd(IntPtr whandle);
+        [DllImport("psapi.dll")]
+        static extern uint GetModuleFileNameEx(IntPtr hProcess, IntPtr hModule, [Out] StringBuilder lpBaseName, [In] [MarshalAs(UnmanagedType.U4)] int nSize);
+		
         private string GetActiveWindowsProcessname()
         {
             try
             {
-                IntPtr handle = IntPtr.Zero;
-                handle = GetForegroundWindow();
+                IntPtr windowHandle = IntPtr.Zero;
+                IntPtr processhandle = IntPtr.Zero;
+                IntPtr zeroHandle = IntPtr.Zero;
+                windowHandle = GetForegroundWindow();
+                processhandle = GetProcessHandleFromHwnd(windowHandle);
 
-                uint processId;
-                if (GetWindowThreadProcessId(handle, out processId) > 0)
-                {
-                    return Process.GetProcessById((int)processId).MainModule.FileName;
-                }
-                else
-                {
-                    return "";
-                }
+                StringBuilder sb = new StringBuilder(4048);
+                GetModuleFileNameEx(processhandle, zeroHandle, sb, 4048);
+                //Global.logger.LogLine("Process changed: " + sb.ToString(), Logging_Level.Info);
+
+
+
+               return sb.ToString();
             }
             catch (Exception exc)
             {
-                //Console.WriteLine(exc);
                 return "";
             }
         }

--- a/Project-Aurora/GameEventHandler.cs
+++ b/Project-Aurora/GameEventHandler.cs
@@ -160,14 +160,21 @@ namespace Aurora
 
                 StringBuilder sb = new StringBuilder(4048);
                 GetModuleFileNameEx(processhandle, zeroHandle, sb, 4048);
-                //Global.logger.LogLine("Process changed: " + sb.ToString(), Logging_Level.Info);
+                //Global.logger.LogLine("Current Foreground Window: " + sb.ToString(), Logging_Level.Info);
 
+                System.IO.Path.GetFileName(sb.ToString());
 
 
                return sb.ToString();
             }
+            catch (ArgumentException aex)
+            {
+                Global.logger.LogLine("Argument Exception: " + aex);
+                return "";
+            }
             catch (Exception exc)
             {
+                Global.logger.LogLine("Exception in GetActiveWindowsProcessname" + exc);
                 return "";
             }
         }

--- a/Project-Aurora/GameEventHandler.cs
+++ b/Project-Aurora/GameEventHandler.cs
@@ -142,8 +142,6 @@ namespace Aurora
         private const uint EVENT_SYSTEM_MINIMIZESTART = 0x0016;
         private const uint EVENT_SYSTEM_MINIMIZEEND = 0x0017;
 
-        [System.Runtime.InteropServices.DllImport("user32.dll", SetLastError = true)]
-        static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
 
         [DllImport("Oleacc.dll")]
         static extern IntPtr GetProcessHandleFromHwnd(IntPtr whandle);


### PR DESCRIPTION
### Fixes:
#430 
#424

The old Process Detection was using the ProcessModule to get the FilePath. This could cause problems, because games, compiled in x64 can't be accessed in this way.
I changed the detection to only use WINAPI calls, so Aurora don't need to access the Process directly anymore.
### Changes:
I only needed to change the GetActiveWindowsProcessname() Method in GameEventHandler.cs
I'am using the `GetProcessHandleFromHwnd()` call to get the process handle from the foreground window, then i get the full path with the `GetModuleFileNameEx()` call.

No Exception handling is needed, the returned fileName will be an empty string when no foreground window exists.
