### PR TITLE
Getting process names fixes

### DIFF
--- a/Project-Aurora/Project-Aurora/Profiles/LightingStateManager.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/LightingStateManager.cs
@@ -499,7 +499,7 @@ namespace Aurora.Profiles
             UpdateProcess();
 
             string raw_process_name = System.IO.Path.GetFileName(processMonitor.ProcessPath);
-            string process_name = raw_process_name.ToLowerInvariant();
+            string process_name = raw_process_name.ToLower();
 
             EffectsEngine.EffectFrame newFrame = new EffectsEngine.EffectFrame();
 

--- a/Project-Aurora/Project-Aurora/Utils/ActiveProcessMonitor.cs
+++ b/Project-Aurora/Project-Aurora/Utils/ActiveProcessMonitor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -8,97 +9,160 @@ using System.Threading.Tasks;
 
 namespace Aurora.Utils
 {
-    public struct tagLASTINPUTINFO
-    {
-        public uint cbSize;
-        public Int32 dwTime;
-    }
+	public struct tagLASTINPUTINFO
+	{
+		public uint cbSize;
+		public Int32 dwTime;
+	}
 
-    public class ActiveProcessMonitor
-    {
-        private const uint WINEVENT_OUTOFCONTEXT = 0;
-        private const uint EVENT_SYSTEM_FOREGROUND = 3;
-        private const uint EVENT_SYSTEM_MINIMIZESTART = 0x0016;
-        private const uint EVENT_SYSTEM_MINIMIZEEND = 0x0017;
-        delegate void WinEventDelegate(IntPtr hWinEventHook, uint eventType, IntPtr hwnd, int idObject, int idChild, uint dwEventThread, uint dwmsEventTime);
-        private string processPath = string.Empty;
-        public string ProcessPath { get { return processPath; } private set { processPath = value; ActiveProcessChanged?.Invoke(this, null); } }
-        public event EventHandler ActiveProcessChanged;
+	public sealed class ActiveProcessMonitor
+	{
+		private const uint WINEVENT_OUTOFCONTEXT = 0;
+		private const uint EVENT_SYSTEM_FOREGROUND = 3;
+		private const uint EVENT_SYSTEM_MINIMIZESTART = 0x0016;
+		private const uint EVENT_SYSTEM_MINIMIZEEND = 0x0017;
+		delegate void WinEventDelegate(IntPtr hWinEventHook, uint eventType, IntPtr hwnd, int idObject, int idChild, uint dwEventThread, uint dwmsEventTime);
+		private string processPath = string.Empty;
+		public string ProcessPath { get { return processPath; } private set { processPath = value; ActiveProcessChanged?.Invoke(this, null); } }
+		public event EventHandler ActiveProcessChanged;
 
-        static WinEventDelegate dele;
+		static WinEventDelegate dele;
 
-        public ActiveProcessMonitor()
-        {
-            try
-            {
-                dele = new WinEventDelegate(WinEventProc);
-                SetWinEventHook(EVENT_SYSTEM_FOREGROUND, EVENT_SYSTEM_FOREGROUND, IntPtr.Zero, dele, 0, 0, WINEVENT_OUTOFCONTEXT);
-                SetWinEventHook(EVENT_SYSTEM_MINIMIZESTART, EVENT_SYSTEM_MINIMIZEEND, IntPtr.Zero, dele, 0, 0, WINEVENT_OUTOFCONTEXT);
-            }
-            catch(Exception exc)
-            {
+		public ActiveProcessMonitor()
+		{
+			try
+			{
+				dele = new WinEventDelegate(WinEventProc);
+				SetWinEventHook(EVENT_SYSTEM_FOREGROUND, EVENT_SYSTEM_FOREGROUND, IntPtr.Zero, dele, 0, 0, WINEVENT_OUTOFCONTEXT);
+				SetWinEventHook(EVENT_SYSTEM_MINIMIZESTART, EVENT_SYSTEM_MINIMIZEEND, IntPtr.Zero, dele, 0, 0, WINEVENT_OUTOFCONTEXT);
+			}
+			catch (Exception exc)
+			{
 
-            }
-        }
+			}
+		}
 
-        public void WinEventProc(IntPtr hWinEventHook, uint eventType, IntPtr hwnd, int idObject, int idChild, uint dwEventThread, uint dwmsEventTime)
-        {
-            if (Global.Configuration.detection_mode == Settings.ApplicationDetectionMode.WindowsEvents)
-            {
-                GetActiveWindowsProcessname();
-            }
-        }
+		public void WinEventProc(IntPtr hWinEventHook, uint eventType, IntPtr hwnd, int idObject, int idChild, uint dwEventThread, uint dwmsEventTime)
+		{
+			if (Global.Configuration.detection_mode == Settings.ApplicationDetectionMode.WindowsEvents)
+			{
+				GetActiveWindowsProcessname();
+			}
+		}
 
-        [System.Runtime.InteropServices.DllImport("user32.dll")]
-        static extern IntPtr GetForegroundWindow();
+		[DllImport("user32.dll")]
+		static extern IntPtr GetForegroundWindow();
 
-        [DllImport("user32.dll")]
-        static extern IntPtr SetWinEventHook(uint eventMin, uint eventMax, IntPtr hmodWinEventProc, WinEventDelegate lpfnWinEventProc, uint idProcess, uint idThread, uint dwFlags);
+		[DllImport("user32.dll")]
+		static extern IntPtr SetWinEventHook(uint eventMin, uint eventMax, IntPtr hmodWinEventProc, WinEventDelegate lpfnWinEventProc, uint idProcess, uint idThread, uint dwFlags);
 
-        // TODO: Move this to own util
-        [DllImport("user32.dll")]
-        public static extern Boolean GetLastInputInfo(ref tagLASTINPUTINFO plii);
+		// TODO: Move this to own util
+		[DllImport("user32.dll")]
+		public static extern Boolean GetLastInputInfo(ref tagLASTINPUTINFO plii);
 
-        [DllImport("user32.dll", SetLastError = true)]
-        static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
+		[DllImport("user32.dll", SetLastError = true)]
+		static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
 
-        [DllImport("Oleacc.dll")]
-        static extern IntPtr GetProcessHandleFromHwnd(IntPtr whandle);
-        [DllImport("psapi.dll", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode)]
-        static extern uint GetModuleFileNameExW(IntPtr hProcess, IntPtr hModule, [Out] StringBuilder lpBaseName, [In] [MarshalAs(UnmanagedType.U4)] int nSize);
+		[DllImport("Oleacc.dll")]
+		static extern IntPtr GetProcessHandleFromHwnd(IntPtr whandle);
 
-        public void GetActiveWindowsProcessname()
-        {
-            string active_process = getActiveWindowsProcessname();
+		[DllImport("psapi.dll", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode)]
+		static extern uint GetModuleFileNameExW(IntPtr hProcess, IntPtr hModule, [Out] StringBuilder lpBaseName, [In] [MarshalAs(UnmanagedType.U4)] int nSize);
 
-            if (!String.IsNullOrWhiteSpace(active_process))
-                ProcessPath = active_process;
-        }
+		public void GetActiveWindowsProcessname()
+		{
+			string active_process = getActiveWindowsProcessname();
 
-        private string getActiveWindowsProcessname()
-        {
-            IntPtr windowHandle = IntPtr.Zero;
+			if (!String.IsNullOrWhiteSpace(active_process))
+				ProcessPath = active_process;
+		}
 
-            try
-            {
-                if (windowHandle.Equals(IntPtr.Zero))
-                    windowHandle = GetForegroundWindow();
-                uint pid;
-                if (GetWindowThreadProcessId(windowHandle, out pid) > 0)
-                {
-                    Process proc = Process.GetProcessById((int)pid);
-                    string path = proc.MainModule.FileName;
-                    if (!System.IO.File.Exists(path))
-                        throw new Exception($"Found file path does not exist! '{path}'");
-                    return path;
-                }
-            }
-            catch (Exception exc)
-            {
-                Global.logger.LogLine("Exception in GetActiveWindowsProcessname" + exc, Logging_Level.Error);
-            }
+		[Flags]
+		private enum ProcessAccessFlags : uint
+		{
+			All = 0x001F0FFF,
+			Terminate = 0x00000001,
+			CreateThread = 0x00000002,
+			VirtualMemoryOperation = 0x00000008,
+			VirtualMemoryRead = 0x00000010,
+			DuplicateHandle = 0x00000040,
+			CreateProcess = 0x000000080,
+			SetQuota = 0x00000100,
+			SetInformation = 0x00000200,
+			QueryInformation = 0x00000400,
+			QueryLimitedInformation = 0x00001000,
+			Synchronize = 0x00100000
+		}
 
-            /*try
+		[DllImport("kernel32.dll")]
+		private static extern bool QueryFullProcessImageName(IntPtr hprocess, int dwFlags,
+			StringBuilder lpExeName, out int size);
+		[DllImport("kernel32.dll")]
+		private static extern IntPtr OpenProcess(ProcessAccessFlags dwDesiredAccess,
+			bool bInheritHandle, int dwProcessId);
+
+		[DllImport("kernel32.dll", SetLastError = true)]
+		private static extern bool CloseHandle(IntPtr hHandle);
+
+		private static string GetExecutablePath(Process Process)
+		{
+			//If running on Vista or later use the new function
+			if (Environment.OSVersion.Version.Major >= 6)
+			{
+				return GetExecutablePathAboveVista(Process.Id);
+			}
+
+			return Process.MainModule.FileName;
+		}
+
+		private static string GetExecutablePathAboveVista(int ProcessId)
+		{
+			var buffer = new StringBuilder(1024);
+			IntPtr hprocess = OpenProcess(ProcessAccessFlags.QueryLimitedInformation,
+				false, ProcessId);
+			if (hprocess != IntPtr.Zero)
+			{
+				try
+				{
+					int size = buffer.Capacity;
+					if (QueryFullProcessImageName(hprocess, 0, buffer, out size))
+					{
+						return buffer.ToString();
+					}
+				}
+				finally
+				{
+					CloseHandle(hprocess);
+				}
+			}
+			throw new Win32Exception(Marshal.GetLastWin32Error());
+		}
+
+
+		private string getActiveWindowsProcessname()
+		{
+			IntPtr windowHandle = IntPtr.Zero;
+
+			try
+			{
+				if (windowHandle.Equals(IntPtr.Zero))
+					windowHandle = GetForegroundWindow();
+				uint pid;
+				if (GetWindowThreadProcessId(windowHandle, out pid) > 0)
+				{
+					Process proc = Process.GetProcessById((int)pid);
+					string path = GetExecutablePath(proc);
+					if (!System.IO.File.Exists(path))
+						throw new Exception($"Found file path does not exist! '{path}'");
+					return path;
+				}
+			}
+			catch (Exception exc)
+			{
+				Global.logger.LogLine("Exception in GetActiveWindowsProcessname" + exc, Logging_Level.Error);
+			}
+
+			/*try
             {
                 IntPtr processhandle = IntPtr.Zero;
                 IntPtr zeroHandle = IntPtr.Zero;
@@ -129,7 +193,7 @@ namespace Aurora.Utils
                     //throw exc;
             }*/
 
-            return "";
-        }
-    }
+			return "";
+		}
+	}
 }


### PR DESCRIPTION
<!-- Thank you for helping Aurora grow as a community project! We appreciate your help, and would love to see more additions to our code from you! :)  -->

<!-- 
============================
A checklist before submitting a Pull Request
============================
1. Ensure that your code follows the CamelCase naming convention. ( https://en.wikipedia.org/wiki/Camel_case )
2. Ensure that you are making a pull request for the dev branch, and not master branch. ( Master branch commits will not be accepted )
3. Fill out the form below with as much information as you can. Feel free to add more comments if you need to.
 -->

<!-- **List any issues that this PR fixes:** fixes # , etc...
 For example, "Fixes #287 , fixes #100 , and fixes #20" -->

**This pull request proposes the following changes:**
<!-- List changes that this RP includes -->
- Some apps and games (like Blade & Soul) runs with admin rights (i.e. evevated). Built in ```Process.MainModule.FileName``` uses old function that throws access denied exception when target process is elevated, despite of calling process is elevated or not. 
In Vista and above exists a new win function for this task. I've changed code to use it. 
[Here is an article about this bug.](http://www.aboutmycode.com/net-framework/how-to-get-elevated-process-path-in-net/)
- Fix inconsistent lower-casing when comparing process names. In ```LightingStateManager``` ```RegisterEvent()``` used ```ToLower()``` while comparing in ```Update()``` was using ```ToLowerInvariant()```.

