### PR TITLE
Fix G keys mapping for Corsair K95 Platinum keyboard

### DIFF
--- a/Project-Aurora/Project-Aurora/kb_layouts/Extra Features/corsair_k95_platinum_left_features.json
+++ b/Project-Aurora/Project-Aurora/kb_layouts/Extra Features/corsair_k95_platinum_left_features.json
@@ -319,7 +319,7 @@
     },
     {
       "visualName": "G1",
-      "tag": 108,
+      "tag": 110,
       "margin_left": -43.0,
       "margin_top": 0.0,
       "width": 30.0,
@@ -334,7 +334,7 @@
     },
     {
       "visualName": "G2",
-      "tag": 109,
+      "tag": 113,
       "margin_left": -43.0,
       "margin_top": 37.0,
       "width": 30.0,
@@ -349,7 +349,7 @@
     },
     {
       "visualName": "G3",
-      "tag": 110,
+      "tag": 116,
       "margin_left": -43.0,
       "margin_top": 74.0,
       "width": 30.0,
@@ -364,7 +364,7 @@
     },
     {
       "visualName": "G4",
-      "tag": 111,
+      "tag": 119,
       "margin_left": -43.0,
       "margin_top": 111.0,
       "width": 30.0,
@@ -379,7 +379,7 @@
     },
     {
       "visualName": "G5",
-      "tag": 112,
+      "tag": 122,
       "margin_left": -43.0,
       "margin_top": 148.0,
       "width": 30.0,
@@ -394,7 +394,7 @@
     },
     {
       "visualName": "G6",
-      "tag": 113,
+      "tag": 125,
       "margin_left": -43.0,
       "margin_top": 185.0,
       "width": 30.0,


### PR DESCRIPTION
- Small fix in the json for K95 Platinum, some "G keys" at the left were no lighting up at all.