### PR TITLE
Fixed Dying Light Install and uninstall wrapper patch buttons

### DIFF
--- a/Project-Aurora/Project-Aurora/Profiles/DyingLight/Control_DyingLight.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/DyingLight/Control_DyingLight.xaml.cs
@@ -78,12 +78,12 @@ namespace Aurora.Profiles.DyingLight
         private bool InstallWrapper(string installpath = "")
         {
             if (String.IsNullOrWhiteSpace(installpath))
-                installpath = Utils.SteamUtils.GetGamePath(241930);
+                installpath = Utils.SteamUtils.GetGamePath(239140);
 
 
             if (!String.IsNullOrWhiteSpace(installpath))
             {
-                string path = System.IO.Path.Combine(installpath, "x64", "LightFX.dll");
+                string path = System.IO.Path.Combine(installpath, "LightFX.dll");
 
                 if (!File.Exists(path))
                     Directory.CreateDirectory(System.IO.Path.GetDirectoryName(path));
@@ -103,10 +103,10 @@ namespace Aurora.Profiles.DyingLight
 
         private bool UninstallWrapper()
         {
-            String installpath = Utils.SteamUtils.GetGamePath(241930);
+            String installpath = Utils.SteamUtils.GetGamePath(239140);
             if (!String.IsNullOrWhiteSpace(installpath))
             {
-                string path = System.IO.Path.Combine(installpath, "x64", "LightFX.dll");
+                string path = System.IO.Path.Combine(installpath, "LightFX.dll");
 
                 if (File.Exists(path))
                     File.Delete(path);

--- a/Project-Aurora/Project-Aurora/Profiles/LightingStateManager.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/LightingStateManager.cs
@@ -122,7 +122,8 @@ namespace Aurora.Profiles
                 new WormsWMD.WormsWMD(),
                 new Blade_and_Soul.BnS(),
                 new Event_SkypeOverlay(),
-                new ROTTombRaider.ROTTombRaider()
+                new ROTTombRaider.ROTTombRaider(),
+				new DyingLight.DyingLight()
             });
 
             RegisterLayerHandlers(new List<LayerHandlerEntry> {

--- a/Project-Aurora/Project-Aurora/Project-Aurora.csproj
+++ b/Project-Aurora/Project-Aurora/Project-Aurora.csproj
@@ -288,6 +288,7 @@
     <Compile Include="EffectsEngine\Animations\AnimationRectangle.cs" />
     <Compile Include="EffectsEngine\Animations\AnimationTrack.cs" />
     <Compile Include="EffectsEngine\EffectBrush.cs" />
+    <Compile Include="Profiles\DyingLight\DyingLightProfile.cs" />
     <Compile Include="Profiles\Generic\ColorEnhanceProfile.cs" />
     <Compile Include="Profiles\ROT Tomb Raider\Control_ROTTombRaider.xaml.cs">
       <DependentUpon>Control_ROTTombRaider.xaml</DependentUpon>
@@ -512,6 +513,11 @@
       <DependentUpon>Control_TheDivision.xaml</DependentUpon>
     </Compile>
     <Compile Include="Profiles\TheDivision\TheDivisionApplication.cs" />
+    <Compile Include="Profiles\DyingLight\Control_DyingLight.xaml.cs">
+      <DependentUpon>Control_DyingLight.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Profiles\DyingLight\GameEvent_DyingLight.cs" />
+    <Compile Include="Profiles\DyingLight\DyingLightApplication.cs" />
     <Compile Include="Profiles\TheTalosPrinciple\Control_TalosPrinciple.xaml.cs">
       <DependentUpon>Control_TalosPrinciple.xaml</DependentUpon>
     </Compile>
@@ -1194,6 +1200,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>
+    <Page Include="Profiles\DyingLight\Control_DyingLight.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="Profiles\Worms_WMD\Control_WormsWMD.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
@@ -1514,6 +1524,7 @@
     <Resource Include="Resources\FreeForm_ManualColor.png" />
     <Resource Include="Resources\Borderlands2_256x256.png" />
     <Resource Include="Resources\rot_tombraider.png" />
+    <Resource Include="Resources\dl_128x128.png" />
     <Content Include="Resources\SteelSeriesInstall\Step1.png" />
     <Content Include="Resources\SteelSeriesInstall\Step2.png" />
     <Content Include="SDKDLL.dll">

--- a/Project-Aurora/Project-Aurora/Properties/Resources.Designer.cs
+++ b/Project-Aurora/Project-Aurora/Properties/Resources.Designer.cs
@@ -473,6 +473,16 @@ namespace Aurora.Properties {
         /// <summary>
         ///   Looks up a localized resource of type System.Drawing.Bitmap.
         /// </summary>
+		internal static System.Drawing.Bitmap dyinglight {
+            get {
+                object obj = ResourceManager.GetObject("DyingLight", resourceCulture);
+                return ((System.Drawing.Bitmap)(obj));
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized resource of type System.Drawing.Bitmap.
+        /// </summary>
         internal static System.Drawing.Bitmap Save_Icon {
             get {
                 object obj = ResourceManager.GetObject("Save_Icon", resourceCulture);

--- a/Project-Aurora/Project-Aurora/Properties/Resources.resx
+++ b/Project-Aurora/Project-Aurora/Properties/Resources.resx
@@ -262,4 +262,7 @@
   <data name="rot_tombraider" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\Resources\rot_tombraider.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
+  <data name="DyingLight" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\dl_128x128.png;System.Drawing.Bitmap, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
 </root>

--- a/Project-Aurora/Project-Aurora/Utils/JSonUtils.cs
+++ b/Project-Aurora/Project-Aurora/Utils/JSonUtils.cs
@@ -44,6 +44,11 @@ namespace Aurora.Utils
                     return typeof(Profiles.Dota_2.Layers.Dota2HeroAbilityEffectsLayerHandlerProperties);
                 case "Aurora.Profiles.TheDivision.TheDivisionSettings":
                     return typeof(Settings.ApplicationProfile);
+                case "Aurora.Profiles.Overwatch.OverwatchProfile":
+                case "Aurora.Profiles.WormsWMD.WormsWMDProfile":
+                case "Aurora.Profiles.Blade_and_Soul.BnSProfile":
+                    return typeof(Profiles.ColorEnhanceProfile);
+
                 default:
                     if (!typeName.Contains("Overlays") && new Regex(@"Aurora.Profiles.\w+.\w+Settings").IsMatch(typeName))
                         return base.BindToType(assemblyName, typeName.Replace("Settings", "Profile"));


### PR DESCRIPTION
The buttons were patching and unpatching shador of mordor due to incorrect steam appID's.