### PR TITLE
Fix for issue #1046 and #1061

### DIFF
--- a/Project-Aurora/Project-Aurora/Devices/DeviceManager.cs
+++ b/Project-Aurora/Project-Aurora/Devices/DeviceManager.cs
@@ -28,7 +28,7 @@ namespace Aurora.Devices
             Worker.DoWork += WorkerOnDoWork;
             Worker.RunWorkerCompleted += (sender, args) =>
             {
-                if (newFrame)
+                if (newFrame && !Worker.IsBusy)
                     Worker.RunWorkerAsync();
             };
             Worker.WorkerSupportsCancellation = true;


### PR DESCRIPTION
Check if worker is busy before doing another work if for some reason worker sets newFrame to true without finishing last frame.

<!-- Thank you for helping Aurora grow as a community project! We appreciate your help, and would love to see more additions to our code from you! :)  -->

<!-- 
============================
A checklist before submitting a Pull Request
============================
1. Ensure that your code follows the CamelCase naming convention. ( https://en.wikipedia.org/wiki/Camel_case )
2. Ensure that you are making a pull request for the dev branch, and not master branch. ( Master branch commits will not be accepted )
3. Fill out the form below with as much information as you can. Feel free to add more comments if you need to.
 -->

**List any issues that this PR fixes:** fixes # , etc...
<!-- For example, "Fixes #287 , fixes #100 , and fixes #20" -->
Fixes #1061 
Fixes #1046 
**This pull request proposes the following changes:**
<!-- List changes that this RP includes -->
- Fix for worker throwing exception.

**Known issues/To do:**
<!-- List any bugs that are introduced with this PR or anything that needs further development -->
- N/A

