### PR TITLE
Simple Conditional Layer

### DIFF
--- a/Project-Aurora/Project-Aurora/Profiles/LightingStateManager.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/LightingStateManager.cs
@@ -141,6 +141,7 @@ namespace Aurora.Profiles
                 new LayerHandlerEntry("Script", "Script Layer", typeof(ScriptLayerHandler)),
                 new LayerHandlerEntry("Percent", "Percent Effect Layer", typeof(PercentLayerHandler)),
                 new LayerHandlerEntry("PercentGradient", "Percent (Gradient) Effect Layer", typeof(PercentGradientLayerHandler)),
+                new LayerHandlerEntry("Conditional", "Conditional Layer", typeof(ConditionalLayerHandler)),
                 new LayerHandlerEntry("Interactive", "Interactive Layer", typeof(InteractiveLayerHandler) ),
                 new LayerHandlerEntry("ShortcutAssistant", "Shortcut Assistant Layer", typeof(ShortcutAssistantLayerHandler) ),
                 new LayerHandlerEntry("Equalizer", "Audio Visualizer Layer", typeof(EqualizerLayerHandler) ),

--- a/Project-Aurora/Project-Aurora/Project-Aurora.csproj
+++ b/Project-Aurora/Project-Aurora/Project-Aurora.csproj
@@ -298,6 +298,10 @@
     <Compile Include="Profiles\Generic\GameEvent_Generic.cs" />
     <Compile Include="Profiles\Generic\WrapperProfile.cs" />
     <Compile Include="Profiles\Generic_Application\GenericApplicationSettings.cs" />
+    <Compile Include="Settings\Layers\ConditionalLayerHandler.cs" />
+    <Compile Include="Settings\Layers\Control_ConditionalLayer.xaml.cs">
+      <DependentUpon>Control_ConditionalLayer.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Settings\Layers\Control_WrapperLightsLayer.xaml.cs">
       <DependentUpon>Control_WrapperLightsLayer.xaml</DependentUpon>
     </Compile>
@@ -1288,6 +1292,10 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="Settings\Layers\Control_BlinkingLayer.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Settings\Layers\Control_ConditionalLayer.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>

--- a/Project-Aurora/Project-Aurora/Settings/Layers/ConditionalLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/ConditionalLayerHandler.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Controls;
+using Aurora.EffectsEngine;
+using Aurora.Profiles;
+using Newtonsoft.Json;
+
+namespace Aurora.Settings.Layers {
+
+    public class ConditionalLayerProperties : LayerHandlerProperties2Color<ConditionalLayerProperties> {
+
+        public string _ConditionPath { get; set; }
+
+        [JsonIgnore]
+        public string ConditionPath { get { return Logic._ConditionPath ?? _ConditionPath ?? string.Empty; } }
+
+        public ConditionalLayerProperties() : base() { }
+        public ConditionalLayerProperties(bool assign_default = false) : base(assign_default) { }
+    }
+
+    public class ConditionalLayerHandler : LayerHandler<ConditionalLayerProperties> {
+
+        public ConditionalLayerHandler() {
+            _ID = "Conditional";
+        }
+
+        protected override UserControl CreateControl() {
+            return new Control_ConditionalLayer(this);
+        }
+
+        public override EffectLayer Render(IGameState gamestate) {
+            EffectLayer layer = new EffectLayer("Conditional Layer");
+
+            bool result = false;
+            if (Properties.ConditionPath.Length > 0)
+                try {
+                    object tmp = Utils.GameStateUtils.RetrieveGameStateParameter(gamestate, Properties.ConditionPath);
+                    result = (bool)Utils.GameStateUtils.RetrieveGameStateParameter(gamestate, Properties.ConditionPath);
+                } catch { }
+
+            layer.Set(Properties.Sequence, result ? Properties.PrimaryColor : Properties.SecondaryColor);
+            return layer;
+        }
+
+        public override void SetApplication(Application profile) {
+            if (profile != null) {
+                if (!string.IsNullOrWhiteSpace(Properties._ConditionPath) && !profile.ParameterLookup.ContainsKey(Properties._ConditionPath))
+                    Properties._ConditionPath = string.Empty;
+            }
+            (Control as Control_ConditionalLayer).SetProfile(profile);
+            base.SetApplication(profile);
+        }
+    }
+}

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_ConditionalLayer.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_ConditionalLayer.xaml
@@ -1,0 +1,38 @@
+﻿<UserControl x:Class="Aurora.Settings.Layers.Control_ConditionalLayer"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Aurora.Settings.Layers"
+             xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
+             xmlns:Controls="clr-namespace:Aurora.Controls"
+             mc:Ignorable="d" 
+             d:DesignHeight="500" d:DesignWidth="500" Loaded="UserControl_Loaded">
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="95px" />
+            <ColumnDefinition Width="160px" />
+            <ColumnDefinition Width="14px" />
+            <ColumnDefinition Width="230px"/>
+            <ColumnDefinition />
+        </Grid.ColumnDefinitions>
+
+        <Grid.RowDefinitions>
+            <RowDefinition Height="28px" />
+            <RowDefinition Height="28px" />
+            <RowDefinition Height="28px" />
+            <RowDefinition />
+        </Grid.RowDefinitions>
+
+        <Label Content="True Color:" Grid.Row="0" HorizontalAlignment="Stretch" VerticalAlignment="Center" />
+        <xctk:ColorPicker x:Name="trueColor" Grid.Row="0" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="4,2" Height="24" ColorMode="ColorCanvas" UsingAlphaChannel="True" SelectedColorChanged="trueColor_SelectedColorChanged" />
+
+        <Label Content="False Color:" Grid.Row="1" HorizontalAlignment="Stretch" VerticalAlignment="Center" />
+        <xctk:ColorPicker x:Name="falseColor" Grid.Row="1" Grid.Column="1" HorizontalAlignment="Stretch" Margin="4,2" Height="24" ColorMode="ColorCanvas" UsingAlphaChannel="True" SelectedColorChanged="falseColor_SelectedColorChanged" />
+
+        <Label Content="Condition Path:" Grid.Row="2" HorizontalAlignment="Stretch" VerticalAlignment="Center" />
+        <ComboBox x:Name="conditionPath" Grid.Row="2" Grid.Column="1" HorizontalAlignment="Stretch" Margin="4,2" IsEditable="True" TextBoxBase.TextChanged="conditionPath_TextChanged" />
+
+        <Controls:KeySequence x:Name="keySequence" Grid.Column="3" Grid.RowSpan="4" Margin="0,4,0,0" Height="280px" VerticalAlignment="Top" RecordingTag="ConditionalLayer" Title="Affected Keys" SequenceUpdated="keySequence_SequenceUpdated" />
+    </Grid>
+</UserControl>

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_ConditionalLayer.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_ConditionalLayer.xaml.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+using Xceed.Wpf.Toolkit;
+
+namespace Aurora.Settings.Layers {
+    /// <summary>
+    /// Interaction logic for Control_ConditionalLayer.xaml
+    /// </summary>
+    public partial class Control_ConditionalLayer : UserControl {
+
+        private bool settingsset = false;
+        private bool profileset = false;
+
+        public Control_ConditionalLayer() {
+            InitializeComponent();
+        }
+
+        public Control_ConditionalLayer(ConditionalLayerHandler datacontext) {
+            InitializeComponent();
+            this.DataContext = datacontext;
+        }
+
+        public void SetSettings() {
+            if (this.DataContext is ConditionalLayerHandler && !settingsset) {
+                ConditionalLayerHandler context = (ConditionalLayerHandler)this.DataContext;
+                this.trueColor.SelectedColor = Utils.ColorUtils.DrawingColorToMediaColor(context.Properties._PrimaryColor ?? System.Drawing.Color.Empty);
+                this.falseColor.SelectedColor = Utils.ColorUtils.DrawingColorToMediaColor(context.Properties._SecondaryColor ?? System.Drawing.Color.Empty);
+                this.conditionPath.Text = context.Properties._ConditionPath;
+                this.keySequence.Sequence = context.Properties._Sequence;
+
+                settingsset = true;
+            }
+        }
+
+        internal void SetProfile(Profiles.Application profile) {
+            if (profile != null && !profileset) {
+                var var_types_boolean = profile.ParameterLookup?.Where(kvp => Type.GetTypeCode(kvp.Value.Item1) == TypeCode.Boolean);
+                conditionPath.Items.Clear();
+                foreach (var item in var_types_boolean)
+                    conditionPath.Items.Add(item.Key);
+
+                profileset = true;
+            }
+            settingsset = false;
+            this.SetSettings();
+        }
+
+        private void UserControl_Loaded(object sender, RoutedEventArgs e) {
+            SetSettings();
+            this.Loaded -= UserControl_Loaded;
+        }
+
+        private void trueColor_SelectedColorChanged(object sender, RoutedPropertyChangedEventArgs<Color?> e) {
+            if (IsLoaded && settingsset && this.DataContext is ConditionalLayerHandler && (sender as ColorPicker).SelectedColor.HasValue)
+                (this.DataContext as ConditionalLayerHandler).Properties._PrimaryColor = Utils.ColorUtils.MediaColorToDrawingColor((sender as ColorPicker).SelectedColor.Value);
+        }
+
+        private void falseColor_SelectedColorChanged(object sender, RoutedPropertyChangedEventArgs<Color?> e) {
+            if (IsLoaded && settingsset && this.DataContext is ConditionalLayerHandler && (sender as ColorPicker).SelectedColor.HasValue)
+                (this.DataContext as ConditionalLayerHandler).Properties._SecondaryColor = Utils.ColorUtils.MediaColorToDrawingColor((sender as ColorPicker).SelectedColor.Value);
+        }
+
+        private void conditionPath_TextChanged(object sender, TextChangedEventArgs e) {
+            if (IsLoaded && settingsset && this.DataContext is ConditionalLayerHandler)
+                (this.DataContext as ConditionalLayerHandler).Properties._ConditionPath = (sender as ComboBox).Text;
+        }
+
+        private void keySequence_SequenceUpdated(object sender, EventArgs e) {
+            if (IsLoaded && settingsset && this.DataContext is ConditionalLayerHandler)
+                (this.DataContext as ConditionalLayerHandler).Properties._Sequence = (sender as Aurora.Controls.KeySequence).Sequence;
+        }
+    }
+}


### PR DESCRIPTION
Adds a simple conditional layer which allows for key colors to be set based on a boolean value read from a game state integration.

![CS:GO Conditional Layer Example](https://user-images.githubusercontent.com/3984322/40516810-51da7b1e-5faa-11e8-9f04-a6f2e37f0793.png)
