### PR TITLE
Timed Key Layer

### DIFF
--- a/Project-Aurora/Project-Aurora/Profiles/LightingStateManager.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/LightingStateManager.cs
@@ -151,7 +151,8 @@ namespace Aurora.Profiles
                 new LayerHandlerEntry("LockColor", "Lock Color Layer", typeof(LockColourLayerHandler) ),
                 new LayerHandlerEntry("Glitch", "Glitch Effect Layer", typeof(GlitchLayerHandler) ),
                 new LayerHandlerEntry("Animation", "Animation Layer", typeof(AnimationLayerHandler) ),
-                new LayerHandlerEntry("ToggleKey", "Toggle Key Layer", typeof(ToggleKeyLayerHandler))
+                new LayerHandlerEntry("ToggleKey", "Toggle Key Layer", typeof(ToggleKeyLayerHandler)),
+                new LayerHandlerEntry("Timer", "Timer Layer", typeof(TimerLayerHandler))
             }, true);
 
             RegisterLayerHandler(new LayerHandlerEntry("WrapperLights", "Wrapper Lighting Layer", typeof(WrapperLightsLayerHandler)), false);

--- a/Project-Aurora/Project-Aurora/Project-Aurora.csproj
+++ b/Project-Aurora/Project-Aurora/Project-Aurora.csproj
@@ -430,12 +430,16 @@
     <Compile Include="Settings\Layers\Control_ConditionalLayer.xaml.cs">
       <DependentUpon>Control_ConditionalLayer.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Settings\Layers\Control_TimerLayer.xaml.cs">
+      <DependentUpon>Control_TimerLayer.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Settings\Layers\Control_ToggleKeyLayer.xaml.cs">
       <DependentUpon>Control_ToggleKeyLayer.xaml</DependentUpon>
     </Compile>
     <Compile Include="Settings\Layers\Control_WrapperLightsLayer.xaml.cs">
       <DependentUpon>Control_WrapperLightsLayer.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Settings\Layers\TimerLayerHandler.cs" />
     <Compile Include="Settings\Layers\ToggleKeyLayerHandler.cs" />
     <Compile Include="Settings\Layers\WrapperLightsLayerHandler.cs" />
     <Compile Include="Profiles\ROT Tomb Raider\Control_ROTTombRaider.xaml.cs">
@@ -1560,6 +1564,10 @@
     <Page Include="Settings\Layers\Control_ImageLayer.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Settings\Layers\Control_TimerLayer.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Settings\Layers\Control_ToggleKeyLayer.xaml">
       <SubType>Designer</SubType>

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_TimerLayer.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_TimerLayer.xaml
@@ -1,0 +1,53 @@
+﻿<UserControl x:Class="Aurora.Settings.Layers.Control_TimerLayer"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Aurora.Settings.Layers"
+             xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
+             xmlns:Controls="clr-namespace:Aurora.Controls"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+    
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="95px" />
+            <ColumnDefinition Width="160px" />
+            <ColumnDefinition Width="90px" />
+            <ColumnDefinition Width="14px" />
+            <ColumnDefinition Width="230px"/>
+            <ColumnDefinition />
+        </Grid.ColumnDefinitions>
+
+        <Grid.RowDefinitions>
+            <RowDefinition Height="28px" />
+            <RowDefinition Height="28px" />
+            <RowDefinition Height="28px" />
+            <RowDefinition Height="28px" />
+            <RowDefinition Height="28px" />
+            <RowDefinition Height="120px" />
+            <RowDefinition />
+        </Grid.RowDefinitions>
+
+        <Label Content="Default Color:" Grid.Row="0" HorizontalAlignment="Right" />
+        <xctk:ColorPicker x:Name="defaultColor" Grid.Row="0" Grid.Column="1" Margin="4,2" ColorMode="ColorCanvas" UsingAlphaChannel="True" SelectedColorChanged="defaultColor_SelectedColorChanged" />
+
+        <Label Content="Active Color:" Grid.Row="1" HorizontalAlignment="Right" />
+        <xctk:ColorPicker x:Name="activeColor" Grid.Row="1" Grid.Column="1" Margin="4,2" ColorMode="ColorCanvas" UsingAlphaChannel="True" SelectedColorChanged="activeColor_SelectedColorChanged" />
+
+        <Label Content="Duration (ms):" Grid.Row="2" HorizontalAlignment="Right" />
+        <xctk:IntegerUpDown x:Name="timerDuration" Grid.Row="2" Grid.Column="1" Margin="4,2" ValueChanged="timerDuration_ValueChanged" />
+
+        <Label Content="Animation type:" Grid.Row="3" HorizontalAlignment="Right" />
+        <ComboBox x:Name="animationType" Grid.Row="3" Grid.Column="1" Margin="4,2" SelectionChanged="animationType_SelectionChanged" />
+
+        <Label Content="Repeat action:" Grid.Row="4" HorizontalAlignment="Right" />
+        <ComboBox x:Name="repeatAction" Grid.Row="4" Grid.Column="1" Margin="4,2" SelectionChanged="repeatAction_SelectionChanged" />
+        <TextBlock Text="?" ToolTip="What action to take when the key is pressed again while the timer is active." Grid.Row="4" Grid.Column="2" TextDecorations="Underline" HorizontalAlignment="Left" VerticalAlignment="Center" Cursor="Help" />
+
+        <Label Content="Trigger Keys:" Grid.Row="5" HorizontalAlignment="Right" />
+        <Controls:KeyBindList x:Name="triggerKeyList" Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="2" Margin="4,2" KeybindsChanged="triggerKeyList_KeybindsChanged" />
+
+        <Controls:KeySequence x:Name="KeySequence_Keys" Grid.Column="4" Grid.RowSpan="999" Margin="0,4,0,0" Height="280px" VerticalAlignment="Top" RecordingTag="ToggleKeyLayer" Title="Affected Keys" SequenceUpdated="KeySequence_Keys_SequenceUpdated" />
+    </Grid>
+</UserControl>

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_TimerLayer.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_TimerLayer.xaml.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+using Xceed.Wpf.Toolkit;
+
+namespace Aurora.Settings.Layers {
+    /// <summary>
+    /// Interaction logic for Control_TimerLayer.xaml
+    /// </summary>
+    public partial class Control_TimerLayer : UserControl {
+
+        private bool settingsset = false;
+
+        public Control_TimerLayer(TimerLayerHandler context) {
+            InitializeComponent();
+            DataContext = context;
+            Loaded += (obj, e) => SetSettings();
+
+            animationType.Items.Add(TimerLayerAnimationType.OnOff);
+            animationType.Items.Add(TimerLayerAnimationType.Fade);
+
+            repeatAction.Items.Add(TimerLayerRepeatPressAction.Reset);
+            repeatAction.Items.Add(TimerLayerRepeatPressAction.Extend);
+            repeatAction.Items.Add(TimerLayerRepeatPressAction.Ignore);
+        }
+
+        public void SetSettings() {
+            if (DataContext is TimerLayerHandler && !settingsset) {
+                TimerLayerHandlerProperties ctxProps = (DataContext as TimerLayerHandler).Properties;
+                defaultColor.SelectedColor = Utils.ColorUtils.DrawingColorToMediaColor(ctxProps._PrimaryColor ?? System.Drawing.Color.Empty);
+                activeColor.SelectedColor = Utils.ColorUtils.DrawingColorToMediaColor(ctxProps._SecondaryColor ?? System.Drawing.Color.Empty);
+                timerDuration.Value = ctxProps._Duration;
+                animationType.SelectedItem = ctxProps._AnimationType;
+                repeatAction.SelectedItem = ctxProps._RepeatAction;
+                triggerKeyList.Keybinds = ctxProps._TriggerKeys;
+                KeySequence_Keys.Sequence = ctxProps._Sequence;
+                settingsset = true;
+            }
+        }
+
+        private bool CanSave { get { return IsLoaded && settingsset && DataContext is TimerLayerHandler; } }
+        private TimerLayerHandler Context { get { return (TimerLayerHandler)DataContext; } }
+
+        private void defaultColor_SelectedColorChanged(object sender, RoutedPropertyChangedEventArgs<Color?> e) {
+            if (CanSave && (sender as ColorPicker).SelectedColor.HasValue)
+                Context.Properties._PrimaryColor = Utils.ColorUtils.MediaColorToDrawingColor((sender as ColorPicker).SelectedColor.Value);
+        }
+
+        private void activeColor_SelectedColorChanged(object sender, RoutedPropertyChangedEventArgs<Color?> e) {
+            if (CanSave && (sender as ColorPicker).SelectedColor.HasValue)
+                Context.Properties._SecondaryColor = Utils.ColorUtils.MediaColorToDrawingColor((sender as ColorPicker).SelectedColor.Value);
+        }
+
+        private void timerDuration_ValueChanged(object sender, RoutedPropertyChangedEventArgs<object> e) {
+            if (CanSave && (sender as IntegerUpDown).Value.HasValue)
+                Context.Properties._Duration = (sender as IntegerUpDown).Value;
+        }
+
+        private void animationType_SelectionChanged(object sender, SelectionChangedEventArgs e) {
+            if (CanSave)
+                Context.Properties._AnimationType = (TimerLayerAnimationType)(sender as ComboBox).SelectedItem;
+        }
+
+        private void repeatAction_SelectionChanged(object sender, SelectionChangedEventArgs e) {
+            if (CanSave)
+                Context.Properties._RepeatAction = (TimerLayerRepeatPressAction)(sender as ComboBox).SelectedItem;
+        }
+
+        private void triggerKeyList_KeybindsChanged(object sender) {
+            if (CanSave && sender is Controls.KeyBindList)
+                Context.Properties._TriggerKeys = (sender as Controls.KeyBindList).Keybinds;
+        }
+
+        private void KeySequence_Keys_SequenceUpdated(object sender, EventArgs e) {
+            if (CanSave && sender is Controls.KeySequence)
+                Context.Properties._Sequence = (sender as Controls.KeySequence).Sequence;
+        }
+    }
+}

--- a/Project-Aurora/Project-Aurora/Settings/Layers/TimerLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/TimerLayerHandler.cs
@@ -1,0 +1,196 @@
+﻿using Aurora.EffectsEngine;
+using Aurora.EffectsEngine.Animations;
+using Aurora.Profiles;
+using Aurora.Utils;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Timers;
+using System.Windows.Controls;
+
+namespace Aurora.Settings.Layers {
+
+    public class TimerLayerHandlerProperties : LayerHandlerProperties2Color<TimerLayerHandlerProperties> {
+
+        public TimerLayerHandlerProperties() : base() { }
+        public TimerLayerHandlerProperties(bool assign_default) : base(assign_default) { }
+
+        public Keybind[] _TriggerKeys { get; set; }
+        [JsonIgnore]
+        public Keybind[] TriggerKeys { get { return Logic._TriggerKeys ?? _TriggerKeys ?? new Keybind[] { }; } }
+
+        public int? _Duration { get; set; }
+        [JsonIgnore]
+        public int Duration { get { return Logic._Duration ?? _Duration ?? 0; } }
+
+        public TimerLayerAnimationType? _AnimationType { get; set; }
+        [JsonIgnore]
+        public TimerLayerAnimationType AnimationType { get { return Logic._AnimationType ?? _AnimationType ?? TimerLayerAnimationType.OnOff; } }
+
+        public TimerLayerRepeatPressAction? _RepeatAction { get; set; }
+        [JsonIgnore]
+        public TimerLayerRepeatPressAction RepeatAction { get { return Logic._RepeatAction ?? _RepeatAction ?? TimerLayerRepeatPressAction.Reset; } }
+
+        public override void Default() {
+            base.Default();
+            _TriggerKeys = new Keybind[] { };
+            _Duration = 5000;
+            _AnimationType = TimerLayerAnimationType.OnOff;
+            _RepeatAction = TimerLayerRepeatPressAction.Reset;
+        }
+    }
+
+    public class TimerLayerHandler : LayerHandler<TimerLayerHandlerProperties> {
+
+        private CustomTimer timer;
+        private bool isActive = false;
+
+        public TimerLayerHandler() : base() {
+            _ID = "Timer";
+
+            timer = new CustomTimer();
+            timer.Trigger += Timer_Elapsed;
+
+            Global.InputEvents.KeyDown += InputEvents_KeyDown;
+        }
+        
+        public override void Dispose() {
+            base.Dispose();
+            Global.InputEvents.KeyDown -= InputEvents_KeyDown;
+        }
+
+        protected override UserControl CreateControl() {
+            return new Control_TimerLayer(this);
+        }
+
+        public override EffectLayer Render(IGameState gamestate) {
+            EffectLayer layer = new EffectLayer();
+            if (isActive) {
+                switch (Properties.AnimationType) {
+                    case TimerLayerAnimationType.OnOff:
+                        layer.Set(Properties.Sequence, Properties.SecondaryColor);
+                        break;
+
+                    case TimerLayerAnimationType.Fade:
+                        layer.Set(Properties.Sequence, ColorUtils.BlendColors(Properties.SecondaryColor, Properties.PrimaryColor, timer.InterpolationValue));
+                        break;
+                }
+            } else
+                layer.Set(Properties.Sequence, Properties.PrimaryColor);
+            return layer;
+        }
+
+        private void Timer_Elapsed(object sender) {
+            isActive = false;
+        }
+
+        private void InputEvents_KeyDown(object sender, SharpDX.RawInput.KeyboardInputEventArgs e) {
+            foreach (var keybind in Properties.TriggerKeys) {
+                if (keybind.IsPressed()) {
+                    switch (Properties.RepeatAction) {
+                        // Restart the timer from scratch
+                        case TimerLayerRepeatPressAction.Reset:
+                            timer.Reset(Properties.Duration);
+                            isActive = true;
+                            break;
+
+                        case TimerLayerRepeatPressAction.Extend:
+                            timer.Extend(Properties.Duration);
+                            isActive = true;
+                            break;
+                        
+                        case TimerLayerRepeatPressAction.Ignore:
+                            if (!isActive) {
+                                timer.Reset(Properties.Duration);
+                                isActive = true;
+                            }
+                            break;
+                    }
+                    return;
+                }
+            }
+        }
+    }
+
+    class CustomTimer {
+
+        public delegate void TriggerHandler(object sender);
+        public event TriggerHandler Trigger;
+
+        private Timer timer;
+        private double max = 0;
+        private DateTime startAt;
+
+        public CustomTimer() {
+            timer = new Timer();
+            timer.AutoReset = false;
+            timer.Elapsed += Timer_Elapsed;
+        }
+
+        private void Timer_Elapsed(object sender, ElapsedEventArgs e) {
+            Trigger?.Invoke(this);
+            timer.Enabled = false;
+        }
+
+        /// <summary>Stops the timer and restarts it with the given time.</summary>
+        private void SetTimer(double t) {
+            timer.Stop();
+            timer.Interval = t;
+            timer.Start();
+        }
+
+        public void Reset(double t) {
+            SetTimer(t);
+            startAt = DateTime.Now;
+            max = t;
+        }
+
+        public void Extend(double t) {
+            // If the timer's not running, behave like Reset
+            if (!timer.Enabled)
+                Reset(t);
+
+            // If timer is running
+            else {
+                max += t; // extend max
+                SetTimer(max - Current);
+            }
+        }
+
+        /// <summary>Gets how many milliseconds has elapsed since starting timer.</summary>
+        public int Current {
+            get {
+                return (int)(DateTime.Now - startAt).TotalMilliseconds;
+            }
+        }
+
+        /// <summary>Gets how far through the timer is as a value between 0 and 1 (for use with the fade animation mode).</summary>
+        public double InterpolationValue {
+            get {
+                return Current / max;
+            }
+        }
+
+        public void Disponse() {
+            timer.Dispose();
+        }
+    }
+    
+    public enum TimerLayerAnimationType {
+        OnOff,
+        Fade
+    }
+
+    public enum TimerLayerRepeatPressAction {
+        [Description("Reset (restarts the timer)")]
+        Reset,
+        [Description("Extend (adds duration to the timer)")]
+        Extend,
+        [Description("Ignore (ignores presses while timer is active)")]
+        Ignore
+    }
+}


### PR DESCRIPTION
Adds a layer whose sequence is lit in a single color. Then when a keybind is pressed (can be separate from the seqence) the sequence changes to another color for a set duration. After the duration, the keys return to their original color.

Can also be set so that the keys fade back to their original colour instead of abruptly changing.

Multiple "repeat actions" are available to customise what happens if one or more of the keybinds are pressed again while the timer is active:
- Reset (Default) - Restarts the timer when the key is pressed.
- Extend - Adds another duration onto the end of the existing one (so multiple presses stack).
- Ignore - Ignores a keypress while timer is active, and simply continues the existing one.

![image](https://user-images.githubusercontent.com/3984322/41813500-21dd1902-772f-11e8-92c4-a79d2247da9f.png)


Thanks to _amahlaka97_ on Discord for the suggestion!