### PR TITLE
Minor script layer improvements

### DIFF
--- a/Project-Aurora/Project-Aurora/Profiles/Application.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/Application.cs
@@ -506,6 +506,10 @@ namespace Aurora.Profiles
             }
         }
 
+        public void ForceScriptReload() {
+            LoadScripts(GetProfileFolderPath(), true);
+        }
+
         protected void InitalizeScriptSettings(ApplicationProfile profile_settings, bool ignore_removal = false)
         {
             foreach (string id in this.EffectScripts.Keys)

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_ScriptLayer.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_ScriptLayer.xaml
@@ -29,7 +29,7 @@
             <StackPanel Orientation="Horizontal" Grid.ColumnSpan="3" VerticalAlignment="Top" HorizontalAlignment="Stretch">
                 <Label Content="Script:" VerticalAlignment="Center"/>
                 <ComboBox x:Name="cboScripts" Width="160" Margin="5" VerticalAlignment="Center" IsEditable="False" SelectionChanged="cboScripts_SelectionChanged" SelectedValue="{Binding Path=Properties._Script, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
-                <Button x:Name="refreshScriptList" VerticalAlignment="Center" Content="Reload Scripts" ToolTip="Reloads the scripts, updating an existing scripts and showing newly added ones" Margin="5" />
+                <Button x:Name="refreshScriptList" VerticalAlignment="Center" Content="Reload Scripts" ToolTip="Reloads the scripts, updating an existing scripts and showing newly added ones" Margin="5" Click="refreshScriptList_Click" />
             </StackPanel>
 
             <controls:Control_VariableRegistryEditor x:Name="ScriptPropertiesEditor" Grid.Row="1" Margin="20,10" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"/>

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_ScriptLayer.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_ScriptLayer.xaml
@@ -12,14 +12,34 @@
             <utils:ExceptionToStringConverter x:Key="ExceptionToStringConv"/>
         </ResourceDictionary>
     </UserControl.Resources>
+
     <Grid>
-        <Label Content="Script:" HorizontalAlignment="Left" Margin="10,17,0,0" VerticalAlignment="Top" Padding="0"/>
-        <ComboBox x:Name="cboScripts" HorizontalAlignment="Left" Margin="48,14,0,0" VerticalAlignment="Top" Width="130" IsEditable="False" SelectionChanged="cboScripts_SelectionChanged" SelectedValue="{Binding Path=Properties._Script, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
-        <DockPanel>
-            <Border x:Name="brdScriptPropertiesEditor" Margin="10,41,0,0" Padding="5" HorizontalAlignment="Left" VerticalAlignment="Stretch" BorderBrush="{DynamicResource {x:Static SystemColors.AppWorkspaceBrushKey}}" BorderThickness="1" DockPanel.Dock="Left">
-                <controls:Control_VariableRegistryEditor x:Name="ScriptPropertiesEditor" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"/>
-            </Border>
-            <TextBlock x:Name="txtError" Text="{Binding Path=ScriptException, Converter={StaticResource ExceptionToStringConv}}" Foreground="Red" Padding="0" Margin="5,41,0,0" TextWrapping="Wrap"/>
-        </DockPanel>
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="1*" MaxWidth="450" />
+                <ColumnDefinition Width="1px" />
+                <ColumnDefinition Width="1*" MaxWidth="450" />
+                <ColumnDefinition Width="0*" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="34" />
+                <RowDefinition />
+            </Grid.RowDefinitions>
+
+            <StackPanel Orientation="Horizontal" Grid.ColumnSpan="3" VerticalAlignment="Top" HorizontalAlignment="Stretch">
+                <Label Content="Script:" VerticalAlignment="Center"/>
+                <ComboBox x:Name="cboScripts" Width="160" Margin="5" VerticalAlignment="Center" IsEditable="False" SelectionChanged="cboScripts_SelectionChanged" SelectedValue="{Binding Path=Properties._Script, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                <Button x:Name="refreshScriptList" VerticalAlignment="Center" Content="Reload Scripts" ToolTip="Reloads the scripts, updating an existing scripts and showing newly added ones" Margin="5" />
+            </StackPanel>
+
+            <controls:Control_VariableRegistryEditor x:Name="ScriptPropertiesEditor" Grid.Row="1" Margin="20,10" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"/>
+
+            <Rectangle Grid.Row="1" Grid.Column="1" Margin="0.10" HorizontalAlignment="Center" VerticalAlignment="Stretch" Stroke="{DynamicResource {x:Static SystemColors.AppWorkspaceBrushKey}}" />
+
+            <StackPanel Grid.Row="1" Grid.Column="2" Margin="20,10" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                <Label Content="If an error occurs, it will be shown here:" />
+                <TextBlock x:Name="txtError" Text="{Binding Path=ScriptException, Converter={StaticResource ExceptionToStringConv}}" Foreground="Red" TextWrapping="Wrap"/>
+            </StackPanel>
+        </Grid>
     </Grid>
 </UserControl>

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_ScriptLayer.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_ScriptLayer.xaml.cs
@@ -56,5 +56,11 @@ namespace Aurora.Settings.Layers
             ScriptPropertiesEditor.Visibility = varReg == null || varReg.Count == 0 ? Visibility.Hidden : Visibility.Visible;
             ScriptPropertiesEditor.VarRegistrySource = handler.IsScriptValid ? handler.Properties._ScriptProperties : null;
         }
+
+        private void refreshScriptList_Click(object sender, RoutedEventArgs e) {
+            Application.ForceScriptReload();
+            cboScripts.Items.Refresh();
+            cboScripts.IsEnabled = Application.EffectScripts.Keys.Count > 0;
+        }
     }
 }

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_ScriptLayer.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_ScriptLayer.xaml.cs
@@ -53,7 +53,7 @@ namespace Aurora.Settings.Layers
             ScriptLayerHandler handler = (ScriptLayerHandler)this.DataContext;
             this.ScriptPropertiesEditor.RegisteredVariables = handler.GetScriptPropertyRegistry();
             VariableRegistry varReg = this.ScriptPropertiesEditor.RegisteredVariables;
-            this.brdScriptPropertiesEditor.Visibility = varReg == null || varReg.Count == 0 ? Visibility.Hidden : Visibility.Visible;
+            ScriptPropertiesEditor.Visibility = varReg == null || varReg.Count == 0 ? Visibility.Hidden : Visibility.Visible;
             ScriptPropertiesEditor.VarRegistrySource = handler.IsScriptValid ? handler.Properties._ScriptProperties : null;
         }
     }


### PR DESCRIPTION
Cleaned up the interface for the script layer and added the ability to reload scripts.

Previously, Aurora would need to be restarted before script changes or new scripts would be recognised, which was a pain if you were actively developing and testing a script. With this change it is much quicker :)