### PR TITLE
Added mouse events to Global.InputEvents

### DIFF
--- a/Project-Aurora/Project-Aurora/Profiles/LightingStateManager.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/LightingStateManager.cs
@@ -152,7 +152,8 @@ namespace Aurora.Profiles
                 new LayerHandlerEntry("Glitch", "Glitch Effect Layer", typeof(GlitchLayerHandler) ),
                 new LayerHandlerEntry("Animation", "Animation Layer", typeof(AnimationLayerHandler) ),
                 new LayerHandlerEntry("ToggleKey", "Toggle Key Layer", typeof(ToggleKeyLayerHandler)),
-                new LayerHandlerEntry("Timer", "Timer Layer", typeof(TimerLayerHandler))
+                new LayerHandlerEntry("Timer", "Timer Layer", typeof(TimerLayerHandler)),
+                new LayerHandlerEntry("Toolbar", "Toolbar Layer", typeof(ToolbarLayerHandler))
             }, true);
 
             RegisterLayerHandler(new LayerHandlerEntry("WrapperLights", "Wrapper Lighting Layer", typeof(WrapperLightsLayerHandler)), false);

--- a/Project-Aurora/Project-Aurora/Project-Aurora.csproj
+++ b/Project-Aurora/Project-Aurora/Project-Aurora.csproj
@@ -691,6 +691,7 @@
     <Compile Include="Settings\PluginManager.cs" />
     <Compile Include="Devices\SteelSeries\USBHIDCodes.cs" />
     <Compile Include="Utils\JSONUtils.cs" />
+    <Compile Include="Utils\MouseUtils.cs" />
     <Compile Include="Utils\ProcessUtils.cs" />
     <Compile Include="Utils\ActiveProcessMonitor.cs" />
     <None Include="App.config">

--- a/Project-Aurora/Project-Aurora/Project-Aurora.csproj
+++ b/Project-Aurora/Project-Aurora/Project-Aurora.csproj
@@ -436,11 +436,15 @@
     <Compile Include="Settings\Layers\Control_ToggleKeyLayer.xaml.cs">
       <DependentUpon>Control_ToggleKeyLayer.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Settings\Layers\Control_ToolbarLayer.xaml.cs">
+      <DependentUpon>Control_ToolbarLayer.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Settings\Layers\Control_WrapperLightsLayer.xaml.cs">
       <DependentUpon>Control_WrapperLightsLayer.xaml</DependentUpon>
     </Compile>
     <Compile Include="Settings\Layers\TimerLayerHandler.cs" />
     <Compile Include="Settings\Layers\ToggleKeyLayerHandler.cs" />
+    <Compile Include="Settings\Layers\ToolbarLayerHandler.cs" />
     <Compile Include="Settings\Layers\WrapperLightsLayerHandler.cs" />
     <Compile Include="Profiles\ROT Tomb Raider\Control_ROTTombRaider.xaml.cs">
       <DependentUpon>Control_ROTTombRaider.xaml</DependentUpon>
@@ -1571,6 +1575,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Settings\Layers\Control_ToggleKeyLayer.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Settings\Layers\Control_ToolbarLayer.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_ToolbarLayer.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_ToolbarLayer.xaml
@@ -1,0 +1,41 @@
+﻿<UserControl x:Class="Aurora.Settings.Layers.Control_ToolbarLayer"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Aurora.Settings.Layers"
+             xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
+             xmlns:Controls="clr-namespace:Aurora.Controls"
+             mc:Ignorable="d">
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="95px" />
+            <ColumnDefinition Width="160px" />
+            <ColumnDefinition Width="14px" />
+            <ColumnDefinition Width="230px"/>
+            <ColumnDefinition />
+        </Grid.ColumnDefinitions>
+
+        <Grid.RowDefinitions>
+            <RowDefinition Height="28px" />
+            <RowDefinition Height="28px" />
+            <RowDefinition Height="28px" />
+            <RowDefinition Height="28px" />
+            <RowDefinition />
+        </Grid.RowDefinitions>
+
+        <Label Content="Default Color:" Grid.Row="0" HorizontalAlignment="Right" />
+        <xctk:ColorPicker x:Name="DefaultColor" Grid.Row="0" Grid.Column="1" Margin="4,2" ColorMode="ColorCanvas" UsingAlphaChannel="True" SelectedColorChanged="DefaultColor_SelectedColorChanged" />
+
+        <Label Content="Active Color:" Grid.Row="1" HorizontalAlignment="Right" />
+        <xctk:ColorPicker x:Name="ActiveColor" Grid.Row="1" Grid.Column="1" Margin="4,2" ColorMode="ColorCanvas" UsingAlphaChannel="True" SelectedColorChanged="ActiveColor_SelectedColorChanged" />
+
+        <Label Content="Enable Scroll:" Grid.Row="2" HorizontalAlignment="Right" />
+        <CheckBox x:Name="EnableScroll" Grid.Row="2" Grid.Column="1" VerticalAlignment="Center" Checked="EnableScroll_Checked" Unchecked="EnableScroll_Checked" />
+
+        <Label Content="Scroll Loop:" Grid.Row="3" HorizontalAlignment="Right" />
+        <CheckBox x:Name="ScrollLoop" Grid.Row="3" Grid.Column="1" VerticalAlignment="Center" Checked="ScrollLoop_Checked" Unchecked="ScrollLoop_Checked" />
+
+        <Controls:KeySequence x:Name="Keys" Grid.Column="3" Grid.RowSpan="999" Margin="0,4,0,0" Height="280px" VerticalAlignment="Top" RecordingTag="ToggleKeyLayer" Title="Affected Keys" SequenceUpdated="Keys_SequenceUpdated" />
+    </Grid>
+</UserControl>

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_ToolbarLayer.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_ToolbarLayer.xaml.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+using Xceed.Wpf.Toolkit;
+
+namespace Aurora.Settings.Layers {
+    /// <summary>
+    /// Interaction logic for Control_ToolbarLayer.xaml
+    /// </summary>
+    public partial class Control_ToolbarLayer : UserControl {
+
+        private bool settingsset = false;
+
+        public Control_ToolbarLayer(ToolbarLayerHandler context) {
+            InitializeComponent();
+            DataContext = context;
+            Loaded += (obj, e) => SetSettings();
+        }
+
+        public void SetSettings() {
+            if (DataContext is ToolbarLayerHandler && !settingsset) {
+                ToolbarLayerHandlerProperties ctxProps = (DataContext as ToolbarLayerHandler).Properties;
+                DefaultColor.SelectedColor = Utils.ColorUtils.DrawingColorToMediaColor(ctxProps._PrimaryColor ?? System.Drawing.Color.Empty);
+                ActiveColor.SelectedColor = Utils.ColorUtils.DrawingColorToMediaColor(ctxProps._SecondaryColor ?? System.Drawing.Color.Empty);
+                EnableScroll.IsChecked = ctxProps._EnableScroll;
+                ScrollLoop.IsChecked = ctxProps._ScrollLoop;
+                Keys.Sequence = ctxProps._Sequence;
+                settingsset = true;
+            }
+        }
+
+        private bool CanSave { get { return IsLoaded && settingsset && DataContext is ToolbarLayerHandler; } }
+        private ToolbarLayerHandler Context { get { return (ToolbarLayerHandler)DataContext; } }
+
+        private void DefaultColor_SelectedColorChanged(object sender, RoutedPropertyChangedEventArgs<Color?> e) {
+            if (CanSave && (sender as ColorPicker).SelectedColor.HasValue)
+                Context.Properties._PrimaryColor = Utils.ColorUtils.MediaColorToDrawingColor((sender as ColorPicker).SelectedColor.Value);
+        }
+
+        private void ActiveColor_SelectedColorChanged(object sender, RoutedPropertyChangedEventArgs<Color?> e) {
+            if (CanSave && (sender as ColorPicker).SelectedColor.HasValue)
+                Context.Properties._SecondaryColor = Utils.ColorUtils.MediaColorToDrawingColor((sender as ColorPicker).SelectedColor.Value);
+        }
+
+        private void EnableScroll_Checked(object sender, RoutedEventArgs e) {
+            if (CanSave)
+                Context.Properties._EnableScroll = (sender as CheckBox).IsChecked ?? false;
+        }
+
+        private void ScrollLoop_Checked(object sender, RoutedEventArgs e) {
+            if (CanSave)
+                Context.Properties._ScrollLoop = (sender as CheckBox).IsChecked ?? false;
+        }
+
+        private void Keys_SequenceUpdated(object sender, EventArgs e) {
+            if (CanSave && sender is Controls.KeySequence)
+                Context.Properties._Sequence = (sender as Controls.KeySequence).Sequence;
+        }
+    }
+}

--- a/Project-Aurora/Project-Aurora/Settings/Layers/ToolbarLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/ToolbarLayerHandler.cs
@@ -1,0 +1,109 @@
+﻿using Aurora.Devices;
+using Aurora.EffectsEngine;
+using Aurora.Profiles;
+using Aurora.Utils;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Controls;
+
+namespace Aurora.Settings.Layers {
+
+    public class ToolbarLayerHandlerProperties : LayerHandlerProperties2Color<ToolbarLayerHandlerProperties> {
+
+        public ToolbarLayerHandlerProperties() : base() { }
+        public ToolbarLayerHandlerProperties(bool assign_default) : base(assign_default) { }
+
+        public bool? _EnableScroll { get; set; }
+        [JsonIgnore]
+        public bool EnableScroll { get { return Logic._EnableScroll ?? _EnableScroll ?? false; } }
+
+        public bool? _ScrollLoop { get; set; }
+        [JsonIgnore]
+        public bool ScrollLoop { get { return Logic._ScrollLoop ?? _ScrollLoop ?? true; } }
+
+        public override void Default() {
+            base.Default();
+            _EnableScroll = false;
+            _ScrollLoop = true;
+        }
+    }
+
+    /// <summary>
+    /// ToolbarLayer as suggested by amahlaka97 on Discord and scroll improvement as suggested by DrMeteor.
+    /// When one of the keys it uses is pressed, that key becomes "active". When another key is pressed, that key becomes active instead.
+    /// Sort of like a radio button but for keys on the keyboard :)
+    /// The mouse scroll wheel can also be used to scroll up and down the active key (if EnableScroll is true).
+    /// </summary>
+    public class ToolbarLayerHandler : LayerHandler<ToolbarLayerHandlerProperties> {
+
+        private DeviceKeys activeKey = DeviceKeys.NONE;
+
+        public ToolbarLayerHandler() {
+            _ID = "Toolbar";
+
+            // Listen for relevant events
+            Global.InputEvents.KeyDown += InputEvents_KeyDown;
+            Global.InputEvents.Scroll += InputEvents_Scroll;
+        }
+
+        public override void Dispose() {
+            // Remove listeners on dispose
+            Global.InputEvents.KeyDown -= InputEvents_KeyDown;
+            Global.InputEvents.Scroll -= InputEvents_Scroll;
+            base.Dispose();
+        }
+
+        protected override UserControl CreateControl() {
+            return new Control_ToolbarLayer(this);
+        }
+        
+        public override EffectLayer Render(IGameState _) {
+            EffectLayer layer = new EffectLayer();
+            foreach (var key in Properties.Sequence.keys)
+                layer.Set(key, key == activeKey ? Properties.SecondaryColor : Properties.PrimaryColor);
+            return layer;
+        }
+
+        /// <summary>
+        /// Handler for when any keyboard button is pressed.
+        /// </summary>
+        private void InputEvents_KeyDown(object sender, SharpDX.RawInput.KeyboardInputEventArgs e) {
+            if (Properties.Sequence.keys.Contains(e.GetDeviceKey()))
+                activeKey = e.GetDeviceKey();
+        }
+
+        /// <summary>
+        /// Handler for the ScrollWheel.
+        /// </summary>
+        private void InputEvents_Scroll(object sender, SharpDX.RawInput.MouseInputEventArgs e) {
+            if (Properties.EnableScroll && Properties.Sequence.keys.Count > 1) {
+                // If there's no active key or the ks doesn't contain it (e.g. the sequence was just changed), make the first one active.
+                if (activeKey == DeviceKeys.NONE || !Properties.Sequence.keys.Contains(activeKey))
+                    activeKey = Properties.Sequence.keys[0];
+
+                // If there's an active key make scroll move up/down
+                else {
+                    // Target index is the current index +/- 1 depending on the scroll value
+                    int idx = Properties.Sequence.keys.IndexOf(activeKey) + (e.WheelDelta > 0 ? -1 : 1);
+
+                    // If scroll loop is enabled, allow the index to wrap around from start to end or end to start.
+                    if (Properties.ScrollLoop) {
+                        if (idx < 0) // If index is now negative (if first item selected and scrolling down), add the length to loop back
+                            idx += Properties.Sequence.keys.Count;
+                        idx = idx % Properties.Sequence.keys.Count;
+
+                        // If scroll loop isn't enabled, cap the index so that it stops at either end
+                    } else {
+                        idx = Math.Max(Math.Min(idx, Properties.Sequence.keys.Count - 1), 0);
+                    }
+
+                    activeKey = Properties.Sequence.keys[idx];
+                }
+            }
+        }
+    }
+}

--- a/Project-Aurora/Project-Aurora/Utils/InputEvents.cs
+++ b/Project-Aurora/Project-Aurora/Utils/InputEvents.cs
@@ -27,11 +27,32 @@ namespace Aurora
         /// </summary>
         public event EventHandler<KeyboardInputEventArgs> KeyUp;
 
+        /// <summary>
+        /// Event that fires when a mouse button is pressed down.
+        /// </summary>
+        public event EventHandler<MouseInputEventArgs> MouseButtonDown;
+
+        /// <summary>
+        /// Event that fires when a mouse button is released.
+        /// </summary>
+        public event EventHandler<MouseInputEventArgs> MouseButtonUp;
+
+        /// <summary>
+        /// Event that fires when the mouse scroll wheel is scrolled.
+        /// </summary>
+        public event EventHandler<MouseInputEventArgs> Scroll;
+
         private readonly List<Keys> pressedKeySequence = new List<Keys>();
+
+        private readonly List<MouseButtons> pressedMouseButtons = new List<MouseButtons>();
 
         public Keys[] PressedKeys
         {
             get { return pressedKeySequence.ToArray(); }
+        }
+
+        public MouseButtons[] PressedButtons {
+            get { return pressedMouseButtons.ToArray(); }
         }
 
         public bool Shift => new[] {Keys.ShiftKey, Keys.RShiftKey, Keys.LShiftKey}
@@ -69,8 +90,8 @@ namespace Aurora
         private void MessagePumpInit()
         {
             using (var dummyForm = new Form())
-            using (new DisposableRawInputHook(UsagePage.Generic, UsageId.GenericKeyboard,
-                DeviceFlags.InputSink, dummyForm.Handle, DeviceOnKeyboardInput))
+            using (new DisposableRawInputHook(UsagePage.Generic, UsageId.GenericKeyboard, UsageId.GenericMouse,
+                DeviceFlags.InputSink, dummyForm.Handle, DeviceOnKeyboardInput, DeviceOnMouseInput))
             {
                 thread.EnterMessageLoop();
             }
@@ -101,27 +122,55 @@ namespace Aurora
             }
         }
 
+        /// <summary>
+        /// Handles a SharpDX MouseInput event and fires the relevant InputEvents event (Scroll, MouseButtonDown or MouseButtonUp).
+        /// </summary>
+        private void DeviceOnMouseInput(object sender, MouseInputEventArgs e) {
+            if (e.WheelDelta != 0)
+                Scroll?.Invoke(sender, e);
+
+            if (e.IsMouseDownEvent()) {
+                if (!pressedMouseButtons.Contains(e.GetMouseButton()))
+                    pressedMouseButtons.Add(e.GetMouseButton());
+                MouseButtonDown?.Invoke(sender, e);
+
+            } else if (e.IsMouseUpEvent()) {
+                pressedMouseButtons.Remove(e.GetMouseButton());
+                MouseButtonUp?.Invoke(sender, e);
+            }
+        }
+
         private sealed class DisposableRawInputHook : IDisposable
         {
             private readonly UsagePage usagePage;
-            private readonly UsageId usageId;
-            private readonly EventHandler<KeyboardInputEventArgs> handler;
+            private readonly UsageId usageIdKeyboard;
+            private readonly UsageId usageIdMouse;
+            private readonly EventHandler<KeyboardInputEventArgs> keyHandler;
+            private readonly EventHandler<MouseInputEventArgs> mouseHandler;
 
-            public DisposableRawInputHook(UsagePage usagePage, UsageId usageId, DeviceFlags flags, IntPtr target,
-                EventHandler<KeyboardInputEventArgs> handler)
+            public DisposableRawInputHook(UsagePage usagePage, UsageId usageIdKeyboard, UsageId usageIdMouse, DeviceFlags flags, IntPtr target,
+                EventHandler<KeyboardInputEventArgs> keyHandler, EventHandler<MouseInputEventArgs> mouseHandler)
             {
                 this.usagePage = usagePage;
-                this.usageId = usageId;
-                this.handler = handler;
+                this.usageIdKeyboard = usageIdKeyboard;
+                this.usageIdMouse = usageIdMouse;
+                this.keyHandler = keyHandler;
+                this.mouseHandler = mouseHandler;
 
-                Device.RegisterDevice(usagePage, usageId, flags, target);
-                Device.KeyboardInput += handler;
+                Device.RegisterDevice(usagePage, usageIdKeyboard, flags, target);
+                Device.KeyboardInput += keyHandler;
+
+                Device.RegisterDevice(usagePage, usageIdMouse, flags, target);
+                Device.MouseInput += mouseHandler;
             }
 
             public void Dispose()
             {
-                Device.KeyboardInput -= handler;
-                Device.RegisterDevice(usagePage, usageId, DeviceFlags.Remove);
+                Device.KeyboardInput -= keyHandler;
+                Device.RegisterDevice(usagePage, usageIdKeyboard, DeviceFlags.Remove);
+
+                Device.MouseInput -= mouseHandler;
+                Device.RegisterDevice(usagePage, usageIdMouse, DeviceFlags.Remove);
             }
         }
 

--- a/Project-Aurora/Project-Aurora/Utils/MouseUtils.cs
+++ b/Project-Aurora/Project-Aurora/Utils/MouseUtils.cs
@@ -1,0 +1,56 @@
+﻿using Aurora.Devices;
+using SharpDX.RawInput;
+using MBF = SharpDX.RawInput.MouseButtonFlags;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace Aurora.Utils {
+    public static class MouseUtils {
+
+        private static MBF[] LeftButtonFlags { get; } = new[] { MBF.Button1Down, MBF.Button1Up, MBF.LeftButtonDown, MBF.LeftButtonUp };
+        private static MBF[] RightButtonFlags { get; } = new[] { MBF.Button2Down, MBF.Button2Up, MBF.RightButtonDown, MBF.RightButtonDown };
+        private static MBF[] MiddleButtonFlags { get; } = new[] { MBF.Button3Down, MBF.Button3Up, MBF.MiddleButtonDown, MBF.MiddleButtonUp };
+        private static MBF[] XButton1Flags { get; } = new[] { MBF.Button4Down, MBF.Button4Up };
+        private static MBF[] XButton2Flags { get; } = new[] { MBF.Button5Down, MBF.Button5Up };
+
+        private static MBF[] ButtonDownFlags { get; } = new[] { MBF.Button1Down, MBF.Button2Down, MBF.Button3Down, MBF.Button4Down, MBF.Button5Down, MBF.LeftButtonDown, MBF.RightButtonDown, MBF.MiddleButtonDown };
+        private static MBF[] ButtonUpFlags { get; } = new[] { MBF.Button1Up, MBF.Button2Up, MBF.Button3Up, MBF.Button4Up, MBF.Button5Up, MBF.LeftButtonUp, MBF.RightButtonUp, MBF.MiddleButtonUp };
+
+        /// <summary>
+        /// Gets the System.Windows.Forms.MouseButtons button for the button that was pressed/released.
+        /// </summary>
+        public static MouseButtons GetMouseButton(this MouseInputEventArgs e) {
+            MBF flags = e.ButtonFlags;
+            if (LeftButtonFlags.Contains(flags))
+                return MouseButtons.Left;
+            else if (RightButtonFlags.Contains(flags))
+                return MouseButtons.Right;
+            else if (MiddleButtonFlags.Contains(flags))
+                return MouseButtons.Middle;
+            else if (XButton1Flags.Contains(flags))
+                return MouseButtons.XButton1;
+            else if (XButton2Flags.Contains(flags))
+                return MouseButtons.XButton2;
+            else
+                return MouseButtons.None;
+        }
+
+        /// <summary>
+        /// Checks if the event is a MouseDown event.
+        /// </summary>
+        public static bool IsMouseDownEvent(this MouseInputEventArgs e) {
+            return ButtonDownFlags.Contains(e.ButtonFlags);
+        }
+
+        /// <summary>
+        /// Checks if the event is a MouseDown event.
+        /// </summary>
+        public static bool IsMouseUpEvent(this MouseInputEventArgs e) {
+            return ButtonUpFlags.Contains(e.ButtonFlags);
+        }
+    }
+}


### PR DESCRIPTION
This allows for layers such as a layer whose highlighted keys depends on the scroll position (consider the toolbar at the bottom of games such as Factorio or Minecraft).

EDIT: Added a ToolbarLayer that utilised the mouse scroll event. This layer was as suggested by amahlaka97 on Discord and the scroll improvement was suggested by DrMeteor/diogotr7. When one of the keys in the sequence it uses is pressed, that key becomes "active". When another key is pressed, that key becomes active instead and resets the others to their default state. It's sort of like a radio button but for the keys on the keyboard. An option is provided that allows the mouse scroll wheel to be used to scroll up and down the active key.