### PR TITLE
Fix crash on startup in case Witcher 3 is not installed

### DIFF
--- a/Project-Aurora/Project-Aurora/Profiles/Witcher3/GameEvent_Witcher3.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/Witcher3/GameEvent_Witcher3.cs
@@ -25,12 +25,16 @@ namespace Aurora.Profiles.Witcher3
         {
             _configRegex = new Regex("\\[Artemis\\](.+?)\\[", RegexOptions.Singleline);
 
-            FileSystemWatcher watcher = new FileSystemWatcher();
-            watcher.Path = Environment.GetFolderPath(Environment.SpecialFolder.Personal) + "\\The Witcher 3";
-            watcher.Changed += dataFile_Changed;
-            watcher.EnableRaisingEvents = true;
+            String settingsFolder = Environment.GetFolderPath(Environment.SpecialFolder.Personal) + "\\The Witcher 3";
+            if (File.Exists(settingsFolder))
+            {
+                FileSystemWatcher watcher = new FileSystemWatcher();
+                watcher.Path = settingsFolder;
+                watcher.Changed += dataFile_Changed;
+                watcher.EnableRaisingEvents = true;
 
-            ReloadData();
+                ReloadData();
+            }
         }
 
         private void dataFile_Changed(object sender, FileSystemEventArgs e)


### PR DESCRIPTION
Closes #1197

**This pull request proposes the following changes:**
<!-- List changes that this PR includes -->
Doesn't check for changes to the config file of Witcher 3 in case it doesn't exist, avoiding a crash