### PR TITLE
Added a dedicated dialog instead of drop down for excluding processes.

### DIFF
--- a/Project-Aurora/Project-Aurora/Project-Aurora.csproj
+++ b/Project-Aurora/Project-Aurora/Project-Aurora.csproj
@@ -553,6 +553,9 @@
       <DependentUpon>Control_ROTTombRaider.xaml</DependentUpon>
     </Compile>
     <Compile Include="Profiles\ROT Tomb Raider\ROTTombRaiderApplication.cs" />
+    <Compile Include="Settings\Window_ProcessSelection.xaml.cs">
+      <DependentUpon>Window_ProcessSelection.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Utils\InputEvents.cs" />
     <Compile Include="Utils\MessagePumpThread.cs" />
     <Compile Include="Utils\InputInterceptor.cs" />
@@ -1848,6 +1851,10 @@
     <Page Include="Controls\Control_VariableRegistryEditor.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Settings\Window_ProcessSelection.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="Settings\Window_VariableRegistryEditor.xaml">
       <SubType>Designer</SubType>

--- a/Project-Aurora/Project-Aurora/Settings/Control_Settings.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Control_Settings.xaml
@@ -132,9 +132,8 @@
                     <TextBlock HorizontalAlignment="Left" Margin="11,230,0,0" TextWrapping="Wrap" Text="Blackout start time:" VerticalAlignment="Top"/>
                     <TextBlock HorizontalAlignment="Left" Margin="12,254,0,0" TextWrapping="Wrap" Text="Blackout end time:" VerticalAlignment="Top"/>
                     <CheckBox x:Name="timed_dimming_with_games_checkbox" Content="Apply timed blackout to game events" HorizontalAlignment="Left" Margin="10,205,0,0" VerticalAlignment="Top" Checked="timed_dimming_with_games_checkbox_Checked" Unchecked="timed_dimming_with_games_checkbox_Checked"/>
-                    <ListBox x:Name="excluded_listbox" HorizontalAlignment="Left" Height="171" Margin="512,96,0,0" VerticalAlignment="Top" Width="160"/>
+                    <ListBox x:Name="excluded_listbox" HorizontalAlignment="Left" Height="199" Margin="512,68,0,-15" VerticalAlignment="Top" Width="160"/>
                     <TextBlock Text="Excluded Processes" HorizontalAlignment="Left" Margin="512,47,0,0" VerticalAlignment="Top" Width="113"/>
-                    <ComboBox x:Name="excluded_process_name" HorizontalAlignment="Left" Height="23" Margin="512,68,0,0" VerticalAlignment="Top" Width="160" IsEditable="True" DropDownOpened="excluded_process_name_DropDownOpened"/>
                     <Button x:Name="excluded_add" Content="Add Process" HorizontalAlignment="Left" Margin="677,68,0,0" VerticalAlignment="Top" Click="excluded_add_Click"/>
                     <Button x:Name="excluded_remove" Content="Remove Process" HorizontalAlignment="Left" Margin="677,96,0,0" VerticalAlignment="Top" Click="excluded_remove_Click"/>
                     <TextBlock HorizontalAlignment="Left" Margin="12,132,0,0" TextWrapping="Wrap" Text="Keyboard brightness modifier: " VerticalAlignment="Top"/>

--- a/Project-Aurora/Project-Aurora/Settings/Control_Settings.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Control_Settings.xaml.cs
@@ -405,13 +405,9 @@ namespace Aurora.Settings
 
         private void excluded_add_Click(object sender, RoutedEventArgs e)
         {
-            if (!String.IsNullOrWhiteSpace(this.excluded_process_name.Text))
-            {
-                if (!Global.Configuration.excluded_programs.Contains(this.excluded_process_name.Text))
-                {
-                    Global.Configuration.excluded_programs.Add(this.excluded_process_name.Text);
-                }
-            }
+            Window_ProcessSelection dialog = new Window_ProcessSelection();
+            if (dialog.ShowDialog() == true && !String.IsNullOrWhiteSpace(dialog.ChosenExecutable)) // do not need to check if dialog is already in excluded_programs since it is a Set and only contains unique items by definition
+                Global.Configuration.excluded_programs.Add(dialog.ChosenExecutable);
 
             load_excluded_listbox();
         }
@@ -965,30 +961,6 @@ namespace Aurora.Settings
                 Global.Configuration.volume_overlay_settings.dim_color = Utils.ColorUtils.MediaColorToDrawingColor(this.volume_overlay_dim_color.SelectedColor.Value);
                 ConfigManager.Save(Global.Configuration);
             }
-        }
-
-        private async void excluded_process_name_DropDownOpened(object sender, EventArgs e)
-        {
-            excluded_process_name.ItemsSource = new string[] { "Working..." };
-
-            HashSet<string> processes = new HashSet<string>();
-            await System.Threading.Tasks.Task.Run(() =>
-            {
-
-                foreach (var p in Process.GetProcesses())
-                {
-                    try
-                    {
-                        processes.Add(Path.GetFileName(p.MainModule.FileName));
-                    }
-                    catch (Exception exc)
-                    {
-
-                    }
-                }
-
-            });
-            excluded_process_name.ItemsSource = processes.ToArray();
         }
 
         private void btnShowBitmapWindow_Click(object sender, RoutedEventArgs e)

--- a/Project-Aurora/Project-Aurora/Settings/Window_ProcessSelection.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Window_ProcessSelection.xaml
@@ -1,0 +1,94 @@
+﻿<Window x:Class="Aurora.Settings.Window_ProcessSelection"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Aurora.Settings"
+             mc:Ignorable="d" 
+             Height="480" Width="340"
+             Title="Exclude process" ResizeMode="NoResize" Background="#181818">
+    <Window.Resources>
+        <local:IconToImageConverter x:Key="IconToImageConverter" />
+    </Window.Resources>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        
+        <TabControl x:Name="MainTabControl" BorderThickness="0">
+            <TabItem Header="Select running process">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    
+                    <ListBox x:Name="RunningProcessList" Margin="0,0,0,10">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition />
+                                    </Grid.ColumnDefinitions>
+                                    <Image Source="{Binding Path=Icon, Converter={StaticResource IconToImageConverter}}" Height="16" Width="16" Margin="2,0,4,0" HorizontalAlignment="Left" />
+                                    <TextBlock Text="{Binding Path=Name}" Grid.Column="1" />
+                                </Grid>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+
+                    <TextBox x:Name="RunningProcessListFilterText" Grid.Row="1" TextChanged="RunningListFilter_TextChanged" PreviewKeyDown="RunningProcessListFilterText_KeyDown" />
+                    <TextBlock IsHitTestVisible="False" Text="Filter list..." VerticalAlignment="Center" HorizontalAlignment="Left" Margin="3,0,0,0" Foreground="#757575" Grid.Row="1">
+                        <TextBlock.Style>
+                            <Style TargetType="{x:Type TextBlock}">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Text, ElementName=RunningProcessListFilterText}" Value="">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                </Grid>
+            </TabItem>
+            
+
+            <TabItem Header="Browse for executable">
+                <Grid Margin="0,10,0,0">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    
+                    <TextBox x:Name="ProcessBrowseResult" />
+                    <TextBlock IsHitTestVisible="False" Text="Browse for executable..." VerticalAlignment="Center" HorizontalAlignment="Left" Margin="3,0,0,0" Foreground="#757575">
+                        <TextBlock.Style>
+                            <Style TargetType="{x:Type TextBlock}">
+                                <Setter Property="Visibility" Value="Collapsed"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding Text, ElementName=ProcessBrowseResult}" Value="">
+                                        <Setter Property="Visibility" Value="Visible"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBlock.Style>
+                    </TextBlock>
+                    
+                    <Button Content="Browse" Grid.Column="1" Margin="10,0,0,0" Padding="5,0" Click="BrowseButton_Click" />
+                </Grid>
+            </TabItem>
+        </TabControl>
+
+        <StackPanel Orientation="Horizontal" Grid.Row="1" HorizontalAlignment="Right" Margin="0,10">
+            <Button Content="Exclude process" Padding="5,0" Click="OkayButton_Click" IsDefault="True" />
+            <Button Content="Cancel" Margin="10,0" Padding="5,0" Click="CancelButton_Click" IsCancel="True" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Project-Aurora/Project-Aurora/Settings/Window_ProcessSelection.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Window_ProcessSelection.xaml.cs
@@ -1,0 +1,148 @@
+﻿using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace Aurora.Settings {
+    public partial class Window_ProcessSelection : Window {
+
+        public Window_ProcessSelection() {
+            InitializeComponent();
+
+            // Scan running processes and add them to a list
+            List<RunningProcess> processList = new List<RunningProcess>();
+            foreach (var p in Process.GetProcesses())
+                try {
+                    // Get the exe name
+                    string name = System.IO.Path.GetFileName(p.MainModule.FileName);
+                    // Check if we've already got an exe by that name, if not add it
+                    if (!processList.Any(x => x.Name == name))
+                        processList.Add(new RunningProcess {
+                            Name = name,
+                            Icon = System.Drawing.Icon.ExtractAssociatedIcon(p.MainModule.FileName)
+                        });
+                } catch { }
+
+            // Sort the list, set the ListBox control to use that list
+            RunningProcessList.ItemsSource = processList.OrderBy(p => p.Name);
+            RunningProcessList.SelectedIndex = 0;
+
+            // CollectionViewSorce to provide search/filter feature
+            CollectionViewSource.GetDefaultView(RunningProcessList.ItemsSource).Filter = RunningProcessFilterPredicate;
+            RunningProcessListFilterText.Focus();
+        }
+
+        /// <summary>The exe that the user has selected to exclude.</summary>
+        public string ChosenExecutable { get; private set; } = "";
+
+        /// <summary>
+        /// Handler for the browse button on the custom exe path tab. Sets
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void BrowseButton_Click(object sender, RoutedEventArgs e) {
+            OpenFileDialog dialog = new OpenFileDialog() {
+                AddExtension = true,
+                Filter = "Executable files (*.exe)|*.exe",
+                Multiselect = false
+            };
+            if (dialog.ShowDialog() == true) // requires "== true" because ShowDialog is a bool?, so doing "if (dialog.ShowDialog())" is invalid
+                ProcessBrowseResult.Text = dialog.FileName;
+        }
+
+        /// <summary>
+        /// Updates the running process filter when the textbox is changed.
+        /// </summary>
+        private void RunningListFilter_TextChanged(object sender, TextChangedEventArgs e) {
+            CollectionViewSource.GetDefaultView(RunningProcessList.ItemsSource).Refresh();
+            if (RunningProcessList.SelectedIndex == -1)
+                RunningProcessList.SelectedIndex = 0;
+        }
+
+        /// <summary>
+        /// Method that makes Up/Down arrow keys when focussed on the RunningListFilter change the selection of the running list element.
+        /// This means you don't have to click on the item when you are typing in a filter.
+        /// We do not need to handle Enter key here as it is done by setting the OK button "IsDefault" to true.
+        /// </summary>
+        private void RunningProcessListFilterText_KeyDown(object sender, KeyEventArgs e) {
+            if (e.Key == Key.Up)
+                RunningProcessList.SelectedIndex = Math.Max(RunningProcessList.SelectedIndex - 1, 0);
+            else if (e.Key == Key.Down)
+                RunningProcessList.SelectedIndex = RunningProcessList.SelectedIndex + 1; // Automatically clamped
+        }
+
+        /// <summary>
+        /// Filter that is run on each item in the running process list (List&lt;RunningProcess&gt;) and returns a bool
+        /// indicating whether it should appear on the list.
+        /// </summary>
+        private bool RunningProcessFilterPredicate(object item) {
+            return ((RunningProcess)item).Name.IndexOf(RunningProcessListFilterText.Text, StringComparison.InvariantCultureIgnoreCase) >= 0;
+        }
+
+        /// <summary>
+        /// Handler for when the confimation button is clicked. Handles closing and informing the result of the dialog.
+        /// </summary>
+        private void OkayButton_Click(object sender, RoutedEventArgs e) {
+            // If the user is on the running process list tab
+            if (MainTabControl.SelectedIndex == 0) {
+                if (RunningProcessList.SelectedItem == null) return; // Cannot OK if there is no item selected
+                ChosenExecutable = ((RunningProcess)RunningProcessList.SelectedItem).Name;
+
+                // Else if user is on browse tab
+            } else {
+                string exe = ProcessBrowseResult.Text;
+                if (String.IsNullOrWhiteSpace(exe)) return; // Cannot OK if there is no text entered
+                // Get just the exe name,
+                ChosenExecutable = exe.Substring(exe.LastIndexOfAny(new[] { '/', '\\' }) + 1);
+            }
+
+            // Close the window and set result as successful
+            DialogResult = true;
+            Close();
+        }
+
+        /// <summary>
+        /// Handler for when the cancel button is clicked. Closes the window.
+        /// </summary>
+        private void CancelButton_Click(object sender, RoutedEventArgs e) {
+            DialogResult = false;
+            Close();
+        }
+    }
+
+
+    /// <summary>
+    /// Converts an Icon into a WPF-compatible BitmapSource.
+    /// </summary>
+    class IconToImageConverter : IValueConverter {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) {
+            Icon ico = (Icon)value;
+            // Taken from https://stackoverflow.com/a/51438725/1305670
+            return System.Windows.Interop.Imaging.CreateBitmapSourceFromHIcon(ico.Handle, Int32Rect.Empty, BitmapSizeOptions.FromEmptyOptions());
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => null;
+    }
+
+    /// <summary>
+    /// Container for a Running Process definition.
+    /// </summary>
+    struct RunningProcess {
+        public string Name { get; set; }
+        public Icon Icon { get; set; }
+    }
+}


### PR DESCRIPTION
Replaced existing dropdown containing running processes with a sorted, searchable list (with icons!) in a dedicated dialog window. Users can also browse to executable files without needing to run them first.

![List showing current running processes.](https://user-images.githubusercontent.com/3984322/45601476-79734380-ba05-11e8-9125-38a18c725a2e.png)

![Option to add a custom (non-running) exe.](https://user-images.githubusercontent.com/3984322/45601478-82fcab80-ba05-11e8-9235-0c0511c061c0.png)

Resolves issue #1259.