### PR TITLE
Added SystemVolume and SystemVolumeIsMuted properties to LocalPCInfo

### DIFF
--- a/Project-Aurora/Project-Aurora/Profiles/GameState.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/GameState.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
+using NAudio.CoreAudioApi;
 
 namespace Aurora.Profiles
 {
@@ -202,12 +203,30 @@ namespace Aurora.Profiles
         /// </summary>
         public long MemoryTotal { get { return PerformanceInfo.GetTotalMemoryInMiB(); } }
 
+        /// <summary>
+        /// Gets the default NAudio endpoint.
+        /// </summary>
+        private MMDevice DefaultAudioDevice => mmDeviceEnumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Console);
+
+        /// <summary>
+        /// Current system volume (as set from the speaker icon)
+        /// </summary>
+        // Note: Manually checks if muted to return 0 since this is not taken into account with the MasterVolumeLevelScalar.
+        public float SystemVolume => SystemVolumeIsMuted ? 0 : DefaultAudioDevice.AudioEndpointVolume.MasterVolumeLevelScalar * 100;
+
+        /// <summary>
+        /// Gets whether the system volume is muted.
+        /// </summary>
+        public bool SystemVolumeIsMuted => DefaultAudioDevice.AudioEndpointVolume.Mute;
+
         private static PerformanceCounter _CPUCounter;
 
         private static float _CPUUsage = 0.0f;
         private static float _SmoothCPUUsage = 0.0f;
 
         private static System.Timers.Timer cpuCounterTimer;
+
+        private static MMDeviceEnumerator mmDeviceEnumerator = new MMDeviceEnumerator();
 
         /// <summary>
         /// Current CPU Usage


### PR DESCRIPTION
 Added `SystemVolume` and `SystemVolumeIsMuted` properties to `LocalPCInfo` state.

`SystemVolume` is a float between 0 - 100 and represents the current system volume as set by the speaker tray icon, designed to be used with the percent layers to show a volume bar.

`SystemVolumeIsMuted` is a (self-explanatory) boolean and can be used with the conditional to highlight when the master system volume is muted.