### PR TITLE
Fixed Visualizer Layer to use 2 channels

### DIFF
--- a/Project-Aurora/Project-Aurora/Settings/Layers/EqualizerLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/EqualizerLayerHandler.cs
@@ -363,10 +363,15 @@ namespace Aurora.Settings.Layers
                 int bytesRecorded = e.BytesRecorded;
                 int bufferIncrement = waveIn.WaveFormat.BlockAlign;
 
-                for (int index = 0; index < bytesRecorded; index += bufferIncrement)
+                // 4 bytes per channel, bufferIncrement is numChannels * 4
+                for (int index = 0; index < bytesRecorded; index += bufferIncrement) // Loop over the bytes, respecting the channel grouping
                 {
-                    float sample32 = BitConverter.ToSingle(buffer, index);
-                    sampleAggregator.Add(sample32);
+                    if (waveIn.WaveFormat.Channels == 2)
+                        // If recording has two channels, take the largest value and add that to the sampleAggregator.
+                        sampleAggregator.Add(Math.Max(BitConverter.ToSingle(buffer, index), BitConverter.ToSingle(buffer, index + 4)));
+                    else
+                        // Fallback to the original if there's only one channel
+                        sampleAggregator.Add(BitConverter.ToSingle(buffer, index));
                 }
             }
         }


### PR DESCRIPTION
 Fixed visualizer layer to be able to use 2 channels if they are present. If so, takes the largest value from the left and right channel and adds to the aggregator. Previously this would only add the left channel, meaning that if there was some audio only in the right channel it would not be displayed on the visualizer.

Resolves issue #1281.