### PR TITLE
Animation rectangles use origin

### DIFF
--- a/Project-Aurora/Project-Aurora/EffectsEngine/Animations/AnimationFilledRectangle.cs
+++ b/Project-Aurora/Project-Aurora/EffectsEngine/Animations/AnimationFilledRectangle.cs
@@ -32,17 +32,18 @@ namespace Aurora.EffectsEngine.Animations
 
             RectangleF _scaledDimension = new RectangleF(_dimension.X * scale, _dimension.Y * scale, _dimension.Width * scale, _dimension.Height * scale);
 
-            PointF rotatePoint = new PointF(_scaledDimension.X + (_scaledDimension.Width / 2.0f), _scaledDimension.Y + (_scaledDimension.Height / 2.0f));
+            PointF rotatePoint = new PointF(_scaledDimension.X, _scaledDimension.Y);
 
-            Matrix rotationMatrix = new Matrix();
-            rotationMatrix.RotateAt(-_angle, rotatePoint, MatrixOrder.Append);
+            Matrix transformationMatrix = new Matrix();
+            transformationMatrix.RotateAt(-_angle, rotatePoint, MatrixOrder.Append);
+            transformationMatrix.Translate(-_scaledDimension.Width / 2f, -_scaledDimension.Height / 2f);
 
             Matrix originalMatrix = g.Transform;
-            g.Transform = rotationMatrix;
+            g.Transform = transformationMatrix;
             g.FillRectangle(_brush, _scaledDimension);
             g.Transform = originalMatrix;
         }
-
+        
         public override AnimationFrame BlendWith(AnimationFrame otherAnim, double amount)
         {
             if (!(otherAnim is AnimationFilledRectangle))

--- a/Project-Aurora/Project-Aurora/EffectsEngine/Animations/AnimationRectangle.cs
+++ b/Project-Aurora/Project-Aurora/EffectsEngine/Animations/AnimationRectangle.cs
@@ -48,13 +48,14 @@ namespace Aurora.EffectsEngine.Animations
             _pen.ScaleTransform(scale, scale);
             RectangleF _scaledDimension = new RectangleF(_dimension.X * scale, _dimension.Y * scale, _dimension.Width * scale, _dimension.Height * scale);
 
-            PointF rotatePoint = new PointF(_scaledDimension.X + (_scaledDimension.Width / 2.0f), _scaledDimension.Y + (_scaledDimension.Height / 2.0f));
+            PointF rotatePoint = new PointF(_scaledDimension.X, _scaledDimension.Y);
 
-            Matrix rotationMatrix = new Matrix();
-            rotationMatrix.RotateAt(-_angle, rotatePoint, MatrixOrder.Append);
+            Matrix transformationMatrix = new Matrix();
+            transformationMatrix.RotateAt(-_angle, rotatePoint, MatrixOrder.Append);
+            transformationMatrix.Translate(-_scaledDimension.Width / 2f, -_scaledDimension.Height / 2f);
 
             Matrix originalMatrix = g.Transform;
-            g.Transform = rotationMatrix;
+            g.Transform = transformationMatrix;
             g.DrawRectangle(_pen, _scaledDimension.X, _scaledDimension.Y, _scaledDimension.Width, _scaledDimension.Height);
             g.Transform = originalMatrix;
 


### PR DESCRIPTION
Made the rectangle and filled rectangle rotate about their origins.

This fixes weird behaviour when changing width/height of rotated rectangles. This may also affect any user-made animations but will be minor and easy to fix.