### PR TITLE
Desktop lock condition

### DIFF
--- a/Project-Aurora/Project-Aurora/App.xaml.cs
+++ b/Project-Aurora/Project-Aurora/App.xaml.cs
@@ -284,6 +284,7 @@ namespace Aurora
                 Global.Configuration.PropertyChanged += SetupVolumeAsBrightness;
                 SetupVolumeAsBrightness(Global.Configuration,
                     new PropertyChangedEventArgs(nameof(Global.Configuration.UseVolumeAsBrightness)));
+                Utils.DesktopUtils.StartSessionWatch();
 
                 Global.key_recorder = new KeyRecorder(Global.InputEvents);
 

--- a/Project-Aurora/Project-Aurora/Profiles/GameState.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/GameState.cs
@@ -203,6 +203,11 @@ namespace Aurora.Profiles
         public long MemoryTotal { get { return PerformanceInfo.GetTotalMemoryInMiB(); } }
 
         /// <summary>
+        /// Returns whether or not the device dession is in a locked state.
+        /// </summary>
+        public bool IsDesktopLocked => Utils.DesktopUtils.IsDesktopLocked;
+
+        /// <summary>
         /// Gets the default endpoint for output (playback) devices e.g. speakers, headphones, etc.
         /// This will return null if there are no playback devices available.
         /// </summary>

--- a/Project-Aurora/Project-Aurora/Project-Aurora.csproj
+++ b/Project-Aurora/Project-Aurora/Project-Aurora.csproj
@@ -565,6 +565,7 @@
     <Compile Include="Settings\Window_ProcessSelection.xaml.cs">
       <DependentUpon>Window_ProcessSelection.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Utils\DesktopUtils.cs" />
     <Compile Include="Utils\InputEvents.cs" />
     <Compile Include="Utils\MessagePumpThread.cs" />
     <Compile Include="Utils\InputInterceptor.cs" />

--- a/Project-Aurora/Project-Aurora/Utils/DesktopUtils.cs
+++ b/Project-Aurora/Project-Aurora/Utils/DesktopUtils.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Aurora.Utils {
+    public static class DesktopUtils {
+
+        public static bool IsDesktopLocked { get; private set; }
+
+        public static void StartSessionWatch() {
+            SystemEvents.SessionSwitch += SystemEvents_SessionSwitch;
+        }
+
+        private static void SystemEvents_SessionSwitch(object sender, SessionSwitchEventArgs e) {
+            if (e.Reason == SessionSwitchReason.SessionLock)
+                IsDesktopLocked = true;
+            else if (e.Reason == SessionSwitchReason.SessionUnlock)
+                IsDesktopLocked = false;
+        }
+    }
+}


### PR DESCRIPTION
Added a boolean condition to the LocalPCInfo node that indicates whether or not the desktop is in a locked state.