### PR TITLE
Added comparison layer

### DIFF
--- a/Project-Aurora/Project-Aurora/Profiles/LightingStateManager.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/LightingStateManager.cs
@@ -159,6 +159,7 @@ namespace Aurora.Profiles
                 new LayerHandlerEntry("Percent", "Percent Effect Layer", typeof(PercentLayerHandler)),
                 new LayerHandlerEntry("PercentGradient", "Percent (Gradient) Effect Layer", typeof(PercentGradientLayerHandler)),
                 new LayerHandlerEntry("Conditional", "Conditional Layer", typeof(ConditionalLayerHandler)),
+                new LayerHandlerEntry("Comparison", "Comparison Layer", typeof(ComparisonLayerHandler)),
                 new LayerHandlerEntry("Interactive", "Interactive Layer", typeof(InteractiveLayerHandler) ),
                 new LayerHandlerEntry("ShortcutAssistant", "Shortcut Assistant Layer", typeof(ShortcutAssistantLayerHandler) ),
                 new LayerHandlerEntry("Equalizer", "Audio Visualizer Layer", typeof(EqualizerLayerHandler) ),

--- a/Project-Aurora/Project-Aurora/Project-Aurora.csproj
+++ b/Project-Aurora/Project-Aurora/Project-Aurora.csproj
@@ -538,7 +538,11 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="Settings\Layers\ComparisonLayerHandler.cs" />
     <Compile Include="Settings\Layers\ConditionalLayerHandler.cs" />
+    <Compile Include="Settings\Layers\Control_ComparisonLayer.xaml.cs">
+      <DependentUpon>Control_ComparisonLayer.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Settings\Layers\Control_ConditionalLayer.xaml.cs">
       <DependentUpon>Control_ConditionalLayer.xaml</DependentUpon>
     </Compile>
@@ -1770,6 +1774,10 @@
     <Page Include="Settings\Layers\Control_BlinkingLayer.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Settings\Layers\Control_ComparisonLayer.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Settings\Layers\Control_ConditionalLayer.xaml">
       <Generator>MSBuild:Compile</Generator>

--- a/Project-Aurora/Project-Aurora/Settings/Layers/ComparisonLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/ComparisonLayerHandler.cs
@@ -1,0 +1,115 @@
+﻿using Aurora.EffectsEngine;
+using Aurora.Profiles;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Controls;
+
+namespace Aurora.Settings.Layers {
+
+    public class ComparisonLayerProperties : LayerHandlerProperties2Color<ComparisonLayerProperties> {
+
+        public string _Operand1Path { get; set; }
+        public string _Operand2Path { get; set; }
+        public ComparisonOperator? _Operator { get; set; }
+
+        [JsonIgnore]
+        public string Operand1Path => Logic._Operand1Path ?? _Operand1Path ?? string.Empty;
+        [JsonIgnore]
+        public string Operand2Path => Logic._Operand2Path ?? _Operand2Path ?? string.Empty;
+        [JsonIgnore]
+        public ComparisonOperator Operator => Logic._Operator ?? _Operator ?? ComparisonOperator.EQ;
+
+        public ComparisonLayerProperties() : base() { }
+        public ComparisonLayerProperties(bool assign_default = false) : base(assign_default) { }
+
+        public override void Default() {
+            base.Default();
+            _Operand1Path = "";
+            _Operand2Path = "";
+            _Operator = ComparisonOperator.EQ;
+        }
+    }
+
+    public class ComparisonLayerHandler : LayerHandler<ComparisonLayerProperties> {
+        
+        public ComparisonLayerHandler() {
+            _ID = "Comparison";
+        }
+
+        protected override UserControl CreateControl() {
+            return new Control_ComparisonLayer(this);
+        }
+
+        public override EffectLayer Render(IGameState gamestate) {
+            // Parse the operands
+            double op1 = GetValue(gamestate, Properties.Operand1Path);
+            double op2 = GetValue(gamestate, Properties.Operand2Path);
+
+            // Evaluate the operands
+            bool cond = false;
+            switch (Properties.Operator) {
+                case ComparisonOperator.EQ: cond = op1 == op2; break;
+                case ComparisonOperator.NEQ: cond = op1 != op2; break;
+                case ComparisonOperator.LT: cond = op1 < op2; break;
+                case ComparisonOperator.LTE: cond = op1 <= op2; break;
+                case ComparisonOperator.GT: cond = op1 > op2; break;
+                case ComparisonOperator.GTE: cond = op1 >= op2; break;
+            }
+
+            // Render the correct color
+            EffectLayer layer = new EffectLayer("Comparison");
+            layer.Set(Properties.Sequence, cond ? Properties.PrimaryColor : Properties.SecondaryColor);
+            return layer;
+        }
+
+        public override void SetApplication(Application profile) {
+            if (profile != null) {
+                if (!double.TryParse(Properties._Operand1Path, out double value) && !string.IsNullOrWhiteSpace(Properties._Operand1Path) && !profile.ParameterLookup.ContainsKey(Properties._Operand1Path))
+                    Properties._Operand1Path = string.Empty;
+                if (!double.TryParse(Properties._Operand2Path, out value) && !string.IsNullOrWhiteSpace(Properties._Operand2Path) && !profile.ParameterLookup.ContainsKey(Properties._Operand2Path))
+                    Properties._Operand2Path = string.Empty;
+            }
+            (Control as Control_ComparisonLayer).SetProfile(profile);
+            base.SetApplication(profile);
+        }
+
+        /// <summary>
+        /// Attempts to get a double value from the game state with the given path.
+        /// </summary>
+        private double GetValue(IGameState state, string path) {
+            if (!double.TryParse(path, out double value) && !string.IsNullOrWhiteSpace(path)) {
+                try {
+                    value = Convert.ToDouble(Utils.GameStateUtils.RetrieveGameStateParameter(state, path));
+                } catch (Exception exc) {
+                    value = 0;
+                    if (Global.isDebug)
+                        throw exc;
+                }
+            }
+            return value;
+        }
+    }
+
+    /// <summary>
+    /// Enum listing various logic operators.
+    /// </summary>
+    public enum ComparisonOperator {
+        [Description("=")]
+        EQ,
+        [Description("≠")]
+        NEQ,
+        [Description("<")]
+        LT,
+        [Description("≤")]
+        LTE,
+        [Description(">")]
+        GT,
+        [Description("≥")]
+        GTE
+    }
+}

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_ComparisonLayer.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_ComparisonLayer.xaml
@@ -1,0 +1,43 @@
+﻿<UserControl x:Class="Aurora.Settings.Layers.Control_ComparisonLayer"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Aurora.Settings.Layers"
+             xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
+             xmlns:Controls="clr-namespace:Aurora.Controls"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800"
+             Loaded="UserControl_Loaded">
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="95px" />
+            <ColumnDefinition Width="180px" />
+            <ColumnDefinition Width="14px" />
+            <ColumnDefinition Width="240px"/>
+            <ColumnDefinition />
+        </Grid.ColumnDefinitions>
+
+        <Grid.RowDefinitions>
+            <RowDefinition Height="28px" />
+            <RowDefinition Height="28px" />
+            <RowDefinition Height="28px" />
+            <RowDefinition />
+        </Grid.RowDefinitions>
+
+        <Label Content="Comparison:" Grid.Row="0" HorizontalAlignment="Stretch" VerticalAlignment="Center" />
+        <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Horizontal" Grid.ColumnSpan="4">
+            <ComboBox x:Name="operand1Path" Width="178" HorizontalAlignment="Stretch" Margin="4,2" IsEditable="True" TextBoxBase.TextChanged="operand1Path_TextChanged" />
+            <ComboBox x:Name="operator" Width="64" HorizontalAlignment="Stretch" Margin="0,2" SelectionChanged="operator_SelectionChanged" />
+            <ComboBox x:Name="operand2Path" Width="178" HorizontalAlignment="Stretch" Margin="4,2" IsEditable="True" TextBoxBase.TextChanged="operand2Path_TextChanged" />
+        </StackPanel>
+
+        <Label Content="True Color:" Grid.Row="1" HorizontalAlignment="Stretch" VerticalAlignment="Center" />
+        <xctk:ColorPicker x:Name="trueColor" Grid.Row="1" Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="4,2" Height="24" ColorMode="ColorCanvas" UsingAlphaChannel="True" SelectedColorChanged="trueColor_SelectedColorChanged" />
+
+        <Label Content="False Color:" Grid.Row="2" HorizontalAlignment="Stretch" VerticalAlignment="Center" />
+        <xctk:ColorPicker x:Name="falseColor" Grid.Row="2" Grid.Column="1" HorizontalAlignment="Stretch" Margin="4,2" Height="24" ColorMode="ColorCanvas" UsingAlphaChannel="True" SelectedColorChanged="falseColor_SelectedColorChanged" />
+
+        <Controls:KeySequence x:Name="keySequence" Grid.Column="3" Grid.Row="1" Grid.RowSpan="4" Margin="0,4,0,0" Height="280px" VerticalAlignment="Top" RecordingTag="ConditionalLayer" Title="Affected Keys" SequenceUpdated="keySequence_SequenceUpdated" />
+    </Grid>
+</UserControl>

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_ComparisonLayer.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_ComparisonLayer.xaml.cs
@@ -1,0 +1,107 @@
+﻿using Aurora.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+using Xceed.Wpf.Toolkit;
+
+namespace Aurora.Settings.Layers {
+    /// <summary>
+    /// Interaction logic for Control_ComparisonLayer.xaml
+    /// </summary>
+    public partial class Control_ComparisonLayer : UserControl {
+
+        private bool settingsset = false;
+        private bool profileset = false;
+
+        public Control_ComparisonLayer() {
+            InitializeComponent();
+
+            // Setup the operator list
+            foreach (var op in Enum.GetValues(typeof(ComparisonOperator)).Cast<ComparisonOperator>())
+                @operator.Items.Add(new KeyValuePair<string, ComparisonOperator>(op.GetDescription(), op));
+            @operator.DisplayMemberPath = "Key";
+        }
+
+        public Control_ComparisonLayer(ComparisonLayerHandler datacontext) : this() {
+            this.DataContext = datacontext;
+        }
+
+        private ComparisonLayerHandler Context => (ComparisonLayerHandler)DataContext;
+        private bool CanSet => IsLoaded && settingsset && DataContext is ComparisonLayerHandler;
+
+        public void SetSettings() {
+            if (DataContext is ComparisonLayerHandler && !settingsset) {
+                operand1Path.Text = Context.Properties._Operand1Path;
+                @operator.SelectedItem = @operator.Items.SourceCollection.Cast<KeyValuePair<string, ComparisonOperator>>().Where(kvp => kvp.Value == Context.Properties.Operator);
+                operand2Path.Text = Context.Properties._Operand2Path;
+                trueColor.SelectedColor = ColorUtils.DrawingColorToMediaColor(Context.Properties._PrimaryColor ?? System.Drawing.Color.Empty);
+                falseColor.SelectedColor = ColorUtils.DrawingColorToMediaColor(Context.Properties._SecondaryColor ?? System.Drawing.Color.Empty);
+                keySequence.Sequence = Context.Properties._Sequence;
+
+                settingsset = true;
+            }
+        }
+
+        internal void SetProfile(Profiles.Application profile) {
+            if (profile != null && !profileset) {
+                var var_types_numerical = profile.ParameterLookup?.Where(kvp => Utils.TypeUtils.IsNumericType(kvp.Value.Item1));
+                operand1Path.Items.Clear();
+                operand2Path.Items.Clear();
+                foreach (var item in var_types_numerical) {
+                    operand1Path.Items.Add(item.Key);
+                    operand2Path.Items.Add(item.Key);
+                }
+
+                profileset = true;
+            }
+            settingsset = false;
+            this.SetSettings();
+        }
+
+        private void UserControl_Loaded(object sender, RoutedEventArgs e) {
+            SetSettings();
+            this.Loaded -= UserControl_Loaded;
+        }
+
+        private void operand1Path_TextChanged(object sender, TextChangedEventArgs e) {
+            if (CanSet)
+                Context.Properties._Operand1Path = (sender as ComboBox).Text;
+        }
+
+        private void operator_SelectionChanged(object sender, SelectionChangedEventArgs e) {
+            if (CanSet)
+                Context.Properties._Operator = ((KeyValuePair<string, ComparisonOperator>)(sender as ComboBox).SelectedItem).Value;
+        }
+
+        private void operand2Path_TextChanged(object sender, TextChangedEventArgs e) {
+            if (CanSet)
+                Context.Properties._Operand2Path = (sender as ComboBox).Text;
+        }
+
+        private void trueColor_SelectedColorChanged(object sender, RoutedPropertyChangedEventArgs<Color?> e) {
+            if (CanSet && (sender as ColorPicker).SelectedColor.HasValue)
+                Context.Properties._PrimaryColor = Utils.ColorUtils.MediaColorToDrawingColor((sender as ColorPicker).SelectedColor.Value);
+        }
+
+        private void falseColor_SelectedColorChanged(object sender, RoutedPropertyChangedEventArgs<Color?> e) {
+            if (CanSet && (sender as ColorPicker).SelectedColor.HasValue)
+                Context.Properties._SecondaryColor = Utils.ColorUtils.MediaColorToDrawingColor((sender as ColorPicker).SelectedColor.Value);
+        }
+
+        private void keySequence_SequenceUpdated(object sender, EventArgs e) {
+            if (CanSet)
+                Context.Properties._Sequence = (sender as Controls.KeySequence).Sequence;
+        }
+    }
+}


### PR DESCRIPTION
Added a comparison layer that can be used to compare two numerical values and change the (solid) color of a key sequence based on the result.

Each operand can either be a path to a game state variable (such as ammo counter, health, speed, etc) or a raw number. The operator can be equals (=), not equal (≠), less than (<), less than or equal (≤), greater than (>) or greater than or equal (≥).

---

Here is an example of it using the Euro Truck Simulator 2 game state to show a red warning if the Engine RPM goes above 80%.

![image](https://user-images.githubusercontent.com/3984322/48199247-79cbf300-e353-11e8-9a2f-04ca3fc74024.png)

![image](https://user-images.githubusercontent.com/3984322/48199322-a4b64700-e353-11e8-9548-b9b2e74d14b3.png)
![image](https://user-images.githubusercontent.com/3984322/48199327-aaac2800-e353-11e8-88cc-0a8b3f70191b.png)
