### PR TITLE
Add Animation Layer Triggers

### DIFF
--- a/Project-Aurora/Project-Aurora/EffectsEngine/Animations/AnimationCircle.cs
+++ b/Project-Aurora/Project-Aurora/EffectsEngine/Animations/AnimationCircle.cs
@@ -75,7 +75,7 @@ namespace Aurora.EffectsEngine.Animations
             _duration = duration;
         }
 
-        public override void Draw(Graphics g, float scale = 1.0f)
+        public override void Draw(Graphics g, float scale = 1.0f, PointF offset = default(PointF))
         {
             if (_pen == null || _invalidated)
             {
@@ -88,6 +88,7 @@ namespace Aurora.EffectsEngine.Animations
 
             _pen.ScaleTransform(scale, scale);
             RectangleF _scaledDimension = new RectangleF(_dimension.X * scale, _dimension.Y * scale, _dimension.Width * scale, _dimension.Height * scale);
+            _scaledDimension.Offset(offset);
 
             Matrix rotationMatrix = new Matrix();
             rotationMatrix.RotateAt(-_angle, new PointF(_center.X * scale, _center.Y * scale), MatrixOrder.Append);

--- a/Project-Aurora/Project-Aurora/EffectsEngine/Animations/AnimationEllipse.cs
+++ b/Project-Aurora/Project-Aurora/EffectsEngine/Animations/AnimationEllipse.cs
@@ -92,7 +92,7 @@ namespace Aurora.EffectsEngine.Animations
             _duration = duration;
         }
 
-        public override void Draw(Graphics g, float scale = 1.0f)
+        public override void Draw(Graphics g, float scale = 1.0f, PointF offset = default(PointF))
         {
             if (_pen == null || _invalidated)
             {
@@ -104,6 +104,7 @@ namespace Aurora.EffectsEngine.Animations
 
             _pen.ScaleTransform(scale, scale);
             RectangleF _scaledDimension = new RectangleF(_dimension.X * scale, _dimension.Y * scale, _dimension.Width * scale, _dimension.Height * scale);
+            _scaledDimension.Offset(offset);
 
             Matrix rotationMatrix = new Matrix();
             rotationMatrix.RotateAt(-_angle, new PointF(_center.X * scale, _center.Y * scale), MatrixOrder.Append);

--- a/Project-Aurora/Project-Aurora/EffectsEngine/Animations/AnimationFill.cs
+++ b/Project-Aurora/Project-Aurora/EffectsEngine/Animations/AnimationFill.cs
@@ -14,14 +14,15 @@ namespace Aurora.EffectsEngine.Animations
         {
         }
 
-        public override void Draw(Graphics g, float scale = 1.0f)
+        public override void Draw(Graphics g, float scale = 1.0f, PointF offset = default(PointF))
         {
+            // Offset has no effect on this. I think.
             if (_brush == null || _invalidated)
             {
                 _brush = new SolidBrush(_color);
                 _invalidated = false;
             }
-
+            
             g.FillRectangle(_brush, g.VisibleClipBounds);
         }
 

--- a/Project-Aurora/Project-Aurora/EffectsEngine/Animations/AnimationFilledCircle.cs
+++ b/Project-Aurora/Project-Aurora/EffectsEngine/Animations/AnimationFilledCircle.cs
@@ -27,7 +27,7 @@ namespace Aurora.EffectsEngine.Animations
         {
         }
 
-        public override void Draw(Graphics g, float scale = 1.0f)
+        public override void Draw(Graphics g, float scale = 1.0f, PointF offset = default(PointF))
         {
             if (_brush == null || _invalidated)
             {
@@ -36,6 +36,7 @@ namespace Aurora.EffectsEngine.Animations
             }
 
             RectangleF _scaledDimension = new RectangleF(_dimension.X * scale, _dimension.Y * scale, _dimension.Width * scale, _dimension.Height * scale);
+            _scaledDimension.Offset(offset);
 
             Matrix rotationMatrix = new Matrix();
             rotationMatrix.RotateAt(-_angle, new PointF(_center.X * scale, _center.Y * scale), MatrixOrder.Append);

--- a/Project-Aurora/Project-Aurora/EffectsEngine/Animations/AnimationFilledGradientRectangle.cs
+++ b/Project-Aurora/Project-Aurora/EffectsEngine/Animations/AnimationFilledGradientRectangle.cs
@@ -30,9 +30,10 @@ namespace Aurora.EffectsEngine.Animations
             _gradientBrush = brush;
         }
 
-        public override void Draw(Graphics g, float scale = 1.0f)
+        public override void Draw(Graphics g, float scale = 1.0f, PointF offset = default(PointF))
         {
             RectangleF _scaledDimension = new RectangleF(_dimension.X * scale, _dimension.Y * scale, _dimension.Width * scale, _dimension.Height * scale);
+            _scaledDimension.Offset(offset);
 
             PointF rotatePoint = new PointF(_scaledDimension.X, _scaledDimension.Y);
 

--- a/Project-Aurora/Project-Aurora/EffectsEngine/Animations/AnimationFilledRectangle.cs
+++ b/Project-Aurora/Project-Aurora/EffectsEngine/Animations/AnimationFilledRectangle.cs
@@ -22,7 +22,7 @@ namespace Aurora.EffectsEngine.Animations
         {
         }
 
-        public override void Draw(Graphics g, float scale = 1.0f)
+        public override void Draw(Graphics g, float scale = 1.0f, PointF offset = default(PointF))
         {
             if (_brush == null || _invalidated)
             {
@@ -31,6 +31,7 @@ namespace Aurora.EffectsEngine.Animations
             }
 
             RectangleF _scaledDimension = new RectangleF(_dimension.X * scale, _dimension.Y * scale, _dimension.Width * scale, _dimension.Height * scale);
+            _scaledDimension.Offset(offset);
 
             PointF rotatePoint = new PointF(_scaledDimension.X, _scaledDimension.Y);
 

--- a/Project-Aurora/Project-Aurora/EffectsEngine/Animations/AnimationFrame.cs
+++ b/Project-Aurora/Project-Aurora/EffectsEngine/Animations/AnimationFrame.cs
@@ -151,7 +151,7 @@ namespace Aurora.EffectsEngine.Animations
             return this;
         }
 
-        public virtual void Draw(Graphics g, float scale = 1.0f) { }
+        public virtual void Draw(Graphics g, float scale = 1.0f, PointF offset = default(PointF)) { }
         public virtual AnimationFrame BlendWith(AnimationFrame otherAnim, double amount)
         {
             amount = GetTransitionValue(amount);

--- a/Project-Aurora/Project-Aurora/EffectsEngine/Animations/AnimationGradientCircle.cs
+++ b/Project-Aurora/Project-Aurora/EffectsEngine/Animations/AnimationGradientCircle.cs
@@ -36,9 +36,10 @@ namespace Aurora.EffectsEngine.Animations
             _gradientBrush = brush;
         }
 
-        public override void Draw(Graphics g, float scale = 1.0f)
+        public override void Draw(Graphics g, float scale = 1.0f, PointF offset = default(PointF))
         {
             RectangleF _scaledDimension = new RectangleF(_dimension.X * scale, _dimension.Y * scale, _dimension.Width * scale, _dimension.Height * scale);
+            _scaledDimension.Offset(offset);
 
             EffectBrush _newbrush = new EffectBrush(_gradientBrush);
             _newbrush.start = new PointF(0.0f, 0.0f);

--- a/Project-Aurora/Project-Aurora/EffectsEngine/Animations/AnimationLine.cs
+++ b/Project-Aurora/Project-Aurora/EffectsEngine/Animations/AnimationLine.cs
@@ -111,13 +111,13 @@ namespace Aurora.EffectsEngine.Animations
             _duration = duration;
         }
 
-        public override void Draw(Graphics g, float scale = 1.0f)
+        public override void Draw(Graphics g, float scale = 1.0f, PointF offset = default(PointF))
         {
             if (_start_point.Equals(_end_point))
                 return;
 
-            PointF _scaledStartPoint = new PointF(_start_point.X * scale, _start_point.Y * scale);
-            PointF _scaledEndPoint = new PointF(_end_point.X * scale, _end_point.Y * scale);
+            PointF _scaledStartPoint = new PointF((_start_point.X * scale) + offset.X, (_start_point.Y * scale) + offset.Y);
+            PointF _scaledEndPoint = new PointF((_end_point.X * scale) + offset.X, (_end_point.Y * scale) + offset.Y);
 
             if (_pen == null || _invalidated)
             {

--- a/Project-Aurora/Project-Aurora/EffectsEngine/Animations/AnimationLines.cs
+++ b/Project-Aurora/Project-Aurora/EffectsEngine/Animations/AnimationLines.cs
@@ -15,10 +15,10 @@ namespace Aurora.EffectsEngine.Animations
             _duration = duration;
         }
 
-        public override void Draw(Graphics g, float scale = 1.0f)
+        public override void Draw(Graphics g, float scale = 1.0f, PointF offset = default(PointF))
         {
             foreach( AnimationLine line in _lines)
-                line.Draw(g, scale);
+                line.Draw(g, scale, offset);
         }
 
         public override AnimationFrame BlendWith(AnimationFrame otherAnim, double amount)

--- a/Project-Aurora/Project-Aurora/EffectsEngine/Animations/AnimationManualColorFrame.cs
+++ b/Project-Aurora/Project-Aurora/EffectsEngine/Animations/AnimationManualColorFrame.cs
@@ -48,8 +48,9 @@ namespace Aurora.EffectsEngine.Animations
             _duration = duration;
         }
 
-        public override void Draw(Graphics g, float scale = 1.0f)
+        public override void Draw(Graphics g, float scale = 1.0f, PointF offset = default(PointF))
         {
+            // Offset has no effect on this type of animation frame
             if (_brush == null || _invalidated)
             {
                 _brush = new SolidBrush(_color);

--- a/Project-Aurora/Project-Aurora/EffectsEngine/Animations/AnimationMix.cs
+++ b/Project-Aurora/Project-Aurora/EffectsEngine/Animations/AnimationMix.cs
@@ -116,7 +116,7 @@ namespace Aurora.EffectsEngine.Animations
             return return_val;
         }
 
-        public void Draw(Graphics g, float time, float scale = 1.0f)
+        public void Draw(Graphics g, float time, float scale = 1.0f, PointF offset = default(PointF))
         {
             Dictionary<string, AnimationTrack> _local = new Dictionary<string, AnimationTrack>(_tracks);
 
@@ -126,7 +126,7 @@ namespace Aurora.EffectsEngine.Animations
                 {
                     try
                     {
-                        track.Value.GetFrame(time).Draw(g, scale);
+                        track.Value.GetFrame(time).Draw(g, scale, offset);
                     }
                     catch (Exception exc)
                     {

--- a/Project-Aurora/Project-Aurora/EffectsEngine/Animations/AnimationRectangle.cs
+++ b/Project-Aurora/Project-Aurora/EffectsEngine/Animations/AnimationRectangle.cs
@@ -34,7 +34,7 @@ namespace Aurora.EffectsEngine.Animations
             _duration = duration;
         }
 
-        public override void Draw(Graphics g, float scale = 1.0f)
+        public override void Draw(Graphics g, float scale = 1.0f, PointF offset = default(PointF))
         {
             if (_pen == null || _invalidated)
             {
@@ -47,6 +47,7 @@ namespace Aurora.EffectsEngine.Animations
 
             _pen.ScaleTransform(scale, scale);
             RectangleF _scaledDimension = new RectangleF(_dimension.X * scale, _dimension.Y * scale, _dimension.Width * scale, _dimension.Height * scale);
+            _scaledDimension.Offset(offset);
 
             PointF rotatePoint = new PointF(_scaledDimension.X, _scaledDimension.Y);
 

--- a/Project-Aurora/Project-Aurora/Settings/Layers/AnimationLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/AnimationLayerHandler.cs
@@ -63,8 +63,8 @@ namespace Aurora.Settings.Layers
             this._AnimationMix = new AnimationMix();
             this._forceKeySequence = false;
             this._scaleToKeySequenceBounds = false;
-            this._AnimationDuration = 0.0f;
-            this._AnimationRepeat = 0;
+            this._AnimationDuration = 0.1f;
+            this._AnimationRepeat = 1;
             this._TriggerMode = AnimationTriggerMode.AlwaysOn;
             this._StackMode = AnimationStackMode.Ignore;
             this._TriggerPath = "";

--- a/Project-Aurora/Project-Aurora/Settings/Layers/AnimationLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/AnimationLayerHandler.cs
@@ -81,6 +81,7 @@ namespace Aurora.Settings.Layers
             this._StackMode = AnimationStackMode.Ignore;
             this._TriggerPath = "";
             this._TriggerKeys = new Keybind[] { };
+            this._TriggerAnyKey = false;
             this._KeyTriggerTranslate = false;
         }
     }

--- a/Project-Aurora/Project-Aurora/Settings/Layers/AnimationLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/AnimationLayerHandler.cs
@@ -63,7 +63,7 @@ namespace Aurora.Settings.Layers
             this._AnimationMix = new AnimationMix();
             this._forceKeySequence = false;
             this._scaleToKeySequenceBounds = false;
-            this._AnimationDuration = 0.1f;
+            this._AnimationDuration = 1;
             this._AnimationRepeat = 1;
             this._TriggerMode = AnimationTriggerMode.AlwaysOn;
             this._StackMode = AnimationStackMode.Ignore;

--- a/Project-Aurora/Project-Aurora/Settings/Layers/AnimationLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/AnimationLayerHandler.cs
@@ -4,6 +4,8 @@ using Aurora.Profiles;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Linq;
@@ -40,8 +42,19 @@ namespace Aurora.Settings.Layers
         [JsonIgnore]
         public int AnimationRepeat { get { return Logic._AnimationRepeat ?? _AnimationRepeat ?? 0; } }
 
-        public AnimationLayerHandlerProperties() : base() { }
+        [JsonIgnore]
+        public AnimationTriggerMode TriggerMode => Logic._TriggerMode ?? _TriggerMode ?? AnimationTriggerMode.AlwaysOn;
+        public AnimationTriggerMode? _TriggerMode { get; set; }
 
+        [JsonIgnore]
+        public AnimationStackMode StackMode => Logic._StackMode ?? _StackMode ?? AnimationStackMode.Ignore;
+        public AnimationStackMode? _StackMode { get; set; }
+
+        [JsonIgnore]
+        public string TriggerPath => Logic._TriggerPath ?? _TriggerPath ?? string.Empty;
+        public string _TriggerPath { get; set; }
+
+        public AnimationLayerHandlerProperties() : base() { }
         public AnimationLayerHandlerProperties(bool assign_default = false) : base(assign_default) { }
 
         public override void Default()
@@ -52,77 +65,164 @@ namespace Aurora.Settings.Layers
             this._scaleToKeySequenceBounds = false;
             this._AnimationDuration = 0.0f;
             this._AnimationRepeat = 0;
+            this._TriggerMode = AnimationTriggerMode.AlwaysOn;
+            this._StackMode = AnimationStackMode.Ignore;
+            this._TriggerPath = "";
         }
     }
 
-    public class AnimationLayerHandler : LayerHandler<AnimationLayerHandlerProperties>
-    {
-        private int _playTimes = 0;
-        private float _previousAnimationTime = 0.0f;
-        private float _currentAnimationTime = 0.0f;
+    public class AnimationLayerHandler : LayerHandler<AnimationLayerHandlerProperties> {
 
-        private float GetAnimationTime()
-        {
-            long _timeDiff = Utils.Time.GetMillisecondsSinceEpoch() - Global.StartTime;
+        private List<RunningAnimation> runningAnimations = new List<RunningAnimation>();
+        private Stopwatch _animTimeStopwatch = new Stopwatch();
+        private double _previousTriggerValue;
 
-            return (_timeDiff / 1000.0f) % float.MaxValue;
-        }
-
-        public AnimationLayerHandler()
-        {
+        public AnimationLayerHandler() {
             _ID = "Animation";
         }
 
-        protected override UserControl CreateControl()
-        {
+        protected override UserControl CreateControl() {
             return new Control_AnimationLayer(this);
         }
 
-        public override EffectLayer Render(IGameState gamestate)
-        {
+        public override EffectLayer Render(IGameState gamestate) {
+            EffectLayer animationLayer = new EffectLayer();
 
-            _previousAnimationTime = _currentAnimationTime;
-            _currentAnimationTime = GetAnimationTime() % Properties.AnimationDuration;
+            // Calculate elapsed time since last Render call
+            long dt = _animTimeStopwatch.ElapsedMilliseconds;
+            _animTimeStopwatch.Restart();
 
-            EffectLayer gradient_layer = new EffectLayer();
+            // Update all running animations
+            runningAnimations.ForEach(anim => {
+                anim.currentTime += dt / 1000f;
+                if (Properties.AnimationRepeat > 0)
+                    anim.playTimes += (int)(anim.currentTime / Properties.AnimationDuration);
+                anim.currentTime %= Properties.AnimationDuration;
+            });
 
+            // Remove any animations that have completed their play times
             if (Properties.AnimationRepeat > 0)
-            {
-                if (_playTimes >= Properties.AnimationRepeat)
-                    return gradient_layer;
+                runningAnimations.RemoveAll(ra => ra.playTimes >= Properties.AnimationRepeat);
 
-                if (_currentAnimationTime < _previousAnimationTime)
-                    _playTimes++;
-            }
-            else
-                _playTimes = 0;
+            // Check to see if the gamestate will cause any animations to trigger
+            if (IsTriggered(gamestate))
+                TriggerAnimation();
 
-            EffectLayer gradient_layer_temp = new EffectLayer();
+            // Render each playing animation
+            runningAnimations.ForEach(anim => {
+                EffectLayer temp = new EffectLayer();
+                using (Graphics g = temp.GetGraphics())
+                    Properties.AnimationMix.Draw(g, anim.currentTime);
+                Console.WriteLine(anim.currentTime);
 
-            using (Graphics g = gradient_layer_temp.GetGraphics())
-            {
-                Properties.AnimationMix.Draw(g, _currentAnimationTime);
-            }
+                Rectangle rect = new Rectangle(0, 0, Effects.canvas_width, Effects.canvas_height);
+                if (Properties.ScaleToKeySequenceBounds) {
+                    var region = Properties.Sequence.GetAffectedRegion();
+                    rect = new Rectangle((int)region.X, (int)region.Y, (int)region.Width, (int)region.Height);
+                }
 
-            Rectangle rect = new Rectangle(0, 0, Effects.canvas_width, Effects.canvas_height);
+                using (Graphics g = animationLayer.GetGraphics())
+                    g.DrawImage(temp.GetBitmap(), rect, new Rectangle(0, 0, Effects.canvas_width, Effects.canvas_height), GraphicsUnit.Pixel);
 
-            if (Properties.ScaleToKeySequenceBounds)
-            {
-                var region = Properties.Sequence.GetAffectedRegion();
-                rect = new Rectangle((int)region.X, (int)region.Y, (int)region.Width, (int)region.Height);
-            }
-
-            using (Graphics g = gradient_layer.GetGraphics())
-            {
-                g.DrawImage(gradient_layer_temp.GetBitmap(), rect, new Rectangle(0, 0, Effects.canvas_width, Effects.canvas_height), GraphicsUnit.Pixel);
-            }
-
-            gradient_layer_temp.Dispose();
+                temp.Dispose();
+            });
 
             if (Properties.ForceKeySequence)
-                gradient_layer.OnlyInclude(Properties.Sequence);
+                animationLayer.OnlyInclude(Properties.Sequence);
 
-            return gradient_layer;
+            return animationLayer;
         }
+
+        /// <summary>
+        /// Checks the current gamestate and checks if the animation layer should be triggered.
+        /// Note will also have the side-effect of updating _previousTriggerValue so this should not be called
+        /// more than once per frame.
+        /// </summary>
+        private bool IsTriggered(IGameState gamestate) {
+            if (Properties.TriggerMode == AnimationTriggerMode.AlwaysOn)
+                // Always should always return true (when there's not an animation already going) and should not try to get a value from the state
+                return true;
+
+            else {
+                // Check to see if a gamestate value change should trigger the animation
+                double resolvedTriggerValue = Utils.GameStateUtils.TryGetDoubleFromState(gamestate, Properties.TriggerPath);
+                bool shouldTrigger = false;
+                switch (Properties.TriggerMode) {
+                    case AnimationTriggerMode.OnChange: shouldTrigger = resolvedTriggerValue != _previousTriggerValue; break;
+                    case AnimationTriggerMode.OnHigh: shouldTrigger = resolvedTriggerValue > _previousTriggerValue; break;
+                    case AnimationTriggerMode.OnLow: shouldTrigger = resolvedTriggerValue < _previousTriggerValue; break;
+                }
+                _previousTriggerValue = resolvedTriggerValue;
+                return shouldTrigger;
+            }
+        }
+
+        /// <summary>
+        /// Triggers a new animation to play depending on the StackMode setting.
+        /// </summary>
+        private void TriggerAnimation() {
+            if (runningAnimations.Count == 0)
+                // If there are no running animations, we will always start a new one
+                runningAnimations.Add(new RunningAnimation());
+
+            else if (Properties.TriggerMode != AnimationTriggerMode.AlwaysOn) // Ignore stack/reset when animation is always on
+                // If there are already running animations, exactly what happens depends on StackMode
+                switch (Properties.StackMode) {
+                    case AnimationStackMode.Reset: runningAnimations[0].Reset(); break;
+                    case AnimationStackMode.Stack: runningAnimations.Add(new RunningAnimation()); break;
+                }
+        }
+
+        public override void SetApplication(Application profile) {
+            // Check to ensure the property specified actually exists
+            if (profile != null && !string.IsNullOrWhiteSpace(Properties._TriggerPath) && !profile.ParameterLookup.ContainsKey(Properties._TriggerPath))
+                Properties._TriggerPath = string.Empty;
+
+            // Tell the control to update (will update the combobox with the possible variable paths)
+            (Control as Control_AnimationLayer).SetProfile(profile);
+
+            base.SetApplication(profile);
+        }
+
+        /// <summary>
+        /// A tiny data class just to store information about
+        /// currently running animations.
+        /// </summary>
+        class RunningAnimation {
+            public float currentTime = 0;
+            public int playTimes = 0;
+
+            public void Reset() {
+                currentTime = 0;
+                playTimes = 0;
+            }
+        }
+    }
+
+    /// <summary>
+    /// An enum of the possible ways for an animation to trigger.
+    /// </summary>
+    public enum AnimationTriggerMode {
+        [Description("Always on")]
+        AlwaysOn,
+        [Description("Trigger on increase")]
+        OnHigh,
+        [Description("Trigger on decrease")]
+        OnLow,
+        [Description("Trigger on change")]
+        OnChange,
+    }
+
+    /// <summary>
+    /// An enum dictating what should happen if a trigger happens while
+    /// an animation is already in progress.
+    /// </summary>
+    public enum AnimationStackMode {
+        [Description("Ignore")]
+        Ignore,
+        [Description("Restart")]
+        Reset,
+        [Description("Play multiple")]
+        Stack
     }
 }

--- a/Project-Aurora/Project-Aurora/Settings/Layers/AnimationLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/AnimationLayerHandler.cs
@@ -120,8 +120,8 @@ namespace Aurora.Settings.Layers
             long dt = _animTimeStopwatch.ElapsedMilliseconds;
             _animTimeStopwatch.Restart();
 
-            // Update all running animations
-            runningAnimations.ForEach(anim => {
+            // Update all running animations. We have to call "ToList()" to prevent "Collection was modified; enumeration operation may not execute"
+            runningAnimations.ToList().ForEach(anim => {
                 anim.currentTime += dt / 1000f;
                 if (Properties.AnimationRepeat > 0)
                     anim.playTimes += (int)(anim.currentTime / Properties.AnimationDuration);
@@ -135,8 +135,8 @@ namespace Aurora.Settings.Layers
             // Check to see if the gamestate will cause any animations to trigger
             CheckTriggers(gamestate);
 
-            // Render each playing animation
-            runningAnimations.ForEach(anim => {
+            // Render each playing animation. We have to call "ToList()" to prevent "Collection was modified; enumeration operation may not execute"
+            runningAnimations.ToList().ForEach(anim => {
                 EffectLayer temp = new EffectLayer();
 
                 // Default values for the destination rect (the area that the canvas is drawn to) and animation offset

--- a/Project-Aurora/Project-Aurora/Settings/Layers/AnimationLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/AnimationLayerHandler.cs
@@ -203,7 +203,7 @@ namespace Aurora.Settings.Layers
     /// An enum of the possible ways for an animation to trigger.
     /// </summary>
     public enum AnimationTriggerMode {
-        [Description("Always on")]
+        [Description("Always on (disable trigger)")]
         AlwaysOn,
         [Description("Trigger on increase")]
         OnHigh,

--- a/Project-Aurora/Project-Aurora/Settings/Layers/AnimationLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/AnimationLayerHandler.cs
@@ -1,6 +1,7 @@
 ﻿using Aurora.EffectsEngine;
 using Aurora.EffectsEngine.Animations;
 using Aurora.Profiles;
+using Aurora.Utils;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -238,7 +239,7 @@ namespace Aurora.Settings.Layers
                     // Do a trigger if waiting for a 'press' event
                     if (Properties.TriggerMode == AnimationTriggerMode.OnKeyPress) {
                         _awaitingTrigger = true;
-                        _awaitingOffset = Effects.GetBitmappingFromDeviceKey(Utils.KeyUtils.GetDeviceKey(e.Key)).Center;
+                        _awaitingOffset = Effects.GetBitmappingFromDeviceKey(e.GetDeviceKey()).Center;
                     }
                     // Mark it as handled
                     _pressedKeys.Add(e.Key);
@@ -255,7 +256,7 @@ namespace Aurora.Settings.Layers
                 if (activedKeybind != null) {
                     if (Properties.TriggerMode == AnimationTriggerMode.OnKeyPress) {
                         _awaitingTrigger = true;
-                        _awaitingOffset = Effects.GetBitmappingFromDeviceKey(Utils.KeyUtils.GetDeviceKey(e.Key)).Center;
+                        _awaitingOffset = Effects.GetBitmappingFromDeviceKey(e.GetDeviceKey()).Center;
                     }
                     _pressedKeybinds.Add(activedKeybind);
                 }
@@ -273,7 +274,7 @@ namespace Aurora.Settings.Layers
                 // Do a trigger if waiting for a 'release' event
                 if (Properties.TriggerMode == AnimationTriggerMode.OnKeyRelease) {
                     _awaitingTrigger = true;
-                    _awaitingOffset = Effects.GetBitmappingFromDeviceKey(Utils.KeyUtils.GetDeviceKey(e.Key)).Center;
+                    _awaitingOffset = Effects.GetBitmappingFromDeviceKey(e.GetDeviceKey()).Center;
                 }
                 // Remove it from the pressed keys so it can be re-detected by the KeyDown event handler
                 _pressedKeys.Remove(e.Key);
@@ -288,7 +289,7 @@ namespace Aurora.Settings.Layers
                 if (deactivatedKeybind != null) {
                     if (Properties.TriggerMode == AnimationTriggerMode.OnKeyRelease) {
                         _awaitingTrigger = true;
-                        _awaitingOffset = Effects.GetBitmappingFromDeviceKey(Utils.KeyUtils.GetDeviceKey(e.Key)).Center;
+                        _awaitingOffset = Effects.GetBitmappingFromDeviceKey(e.GetDeviceKey()).Center;
                     }
                     _pressedKeybinds.Remove(deactivatedKeybind);
                 }

--- a/Project-Aurora/Project-Aurora/Settings/Layers/AnimationLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/AnimationLayerHandler.cs
@@ -68,6 +68,10 @@ namespace Aurora.Settings.Layers
         public bool KeyTriggerTranslate => Logic._KeyTriggerTranslate ?? _KeyTriggerTranslate ?? false;
         public bool? _KeyTriggerTranslate { get; set; }
 
+        [JsonIgnore]
+        public bool WhileKeyHeldTerminateRunning => Logic._WhileKeyHeldTerminateRunning ?? _WhileKeyHeldTerminateRunning ?? false;
+        public bool? _WhileKeyHeldTerminateRunning { get; set; }
+
         public AnimationLayerHandlerProperties() : base() { }
         public AnimationLayerHandlerProperties(bool assign_default = false) : base(assign_default) { }
 
@@ -84,6 +88,7 @@ namespace Aurora.Settings.Layers
             this._TriggerKeys = new Keybind[] { };
             this._TriggerAnyKey = false;
             this._KeyTriggerTranslate = false;
+            this._WhileKeyHeldTerminateRunning = false;
         }
     }
 
@@ -343,6 +348,11 @@ namespace Aurora.Settings.Layers
                     _pressedKeybinds.Remove(deactivatedKeybind);
                 }
             }
+
+            // If we are in "while key held" mode and the user wishes to immediately terminate animations for a key when that key
+            // is released (instead of letting the animation finish first), remove any animations assigned to the given key.
+            if ((Properties.TriggerMode == AnimationTriggerMode.OnKeyPress || Properties.TriggerMode == AnimationTriggerMode.WhileKeyHeld) && Properties.WhileKeyHeldTerminateRunning)
+                runningAnimations.RemoveAll(anim => anim.assignedKey == e.GetDeviceKey());
         }
 
         /// <summary>

--- a/Project-Aurora/Project-Aurora/Settings/Layers/ComparisonLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/ComparisonLayerHandler.cs
@@ -47,8 +47,8 @@ namespace Aurora.Settings.Layers {
 
         public override EffectLayer Render(IGameState gamestate) {
             // Parse the operands
-            double op1 = GetValue(gamestate, Properties.Operand1Path);
-            double op2 = GetValue(gamestate, Properties.Operand2Path);
+            double op1 = Utils.GameStateUtils.TryGetDoubleFromState(gamestate, Properties.Operand1Path);
+            double op2 = Utils.GameStateUtils.TryGetDoubleFromState(gamestate, Properties.Operand2Path);
 
             // Evaluate the operands
             bool cond = false;
@@ -76,22 +76,6 @@ namespace Aurora.Settings.Layers {
             }
             (Control as Control_ComparisonLayer).SetProfile(profile);
             base.SetApplication(profile);
-        }
-
-        /// <summary>
-        /// Attempts to get a double value from the game state with the given path.
-        /// </summary>
-        private double GetValue(IGameState state, string path) {
-            if (!double.TryParse(path, out double value) && !string.IsNullOrWhiteSpace(path)) {
-                try {
-                    value = Convert.ToDouble(Utils.GameStateUtils.RetrieveGameStateParameter(state, path));
-                } catch (Exception exc) {
-                    value = 0;
-                    if (Global.isDebug)
-                        throw exc;
-                }
-            }
-            return value;
         }
     }
 

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml
@@ -29,7 +29,7 @@
             </Grid>
         </GroupBox>
 
-        <GroupBox Header="Trigger" Margin="257,53,0,0" Width="273" Height="300" HorizontalAlignment="Left" VerticalAlignment="Top">
+        <GroupBox Header="Trigger" Margin="257,53,0,0" Width="273" Height="306" HorizontalAlignment="Left" VerticalAlignment="Top">
             <Grid>
                 <Grid x:Name="triggerGridLayout">
                     <Grid.ColumnDefinitions>
@@ -42,6 +42,7 @@
                         <RowDefinition Height="28px" />
                         <RowDefinition Height="156px" />
                         <RowDefinition Height="28px" />
+                        <RowDefinition Height="28px" />
                         <RowDefinition Height="1*" />
                     </Grid.RowDefinitions>
 
@@ -52,17 +53,20 @@
                     <Label Content="Trigger keys:" Grid.Row="2" VerticalAlignment="Top" HorizontalAlignment="Right" />
                     <CheckBox x:Name="triggerAnyKey" Grid.Row="2" Grid.Column="1" Content="Trigger for any key" Margin="4,6" Checked="triggerAnyKey_Checked" Unchecked="triggerAnyKey_Checked" />
                     <Controls:KeyBindList x:Name="triggerKeys" Margin="0,28,0,0" Grid.Row="2" Grid.Column="1" KeybindsChanged="triggerKeys_KeybindsChanged" />
-                    <Label Content="Stack mode:" Grid.Row="3" VerticalAlignment="Center" HorizontalAlignment="Right" />
-                    <ComboBox x:Name="stackModeCb" Grid.Row="3" Grid.Column="1"  Margin="2,4" VerticalAlignment="Center" HorizontalAlignment="Stretch" SelectionChanged="stackModeCb_SelectionChanged" />
+                    <Label Content="Stack mode:" Grid.Row="4" VerticalAlignment="Center" HorizontalAlignment="Right" />
+                    <CheckBox x:Name="translateToKey" Grid.Row="3" Grid.Column="1" Content="Translate to pressed key" Margin="4,6" Checked="translateToKey_Checked" Unchecked="translateToKey_Checked" />
+                    <ComboBox x:Name="stackModeCb" Grid.Row="4" Grid.Column="1"  Margin="2,4" VerticalAlignment="Center" HorizontalAlignment="Stretch" SelectionChanged="stackModeCb_SelectionChanged" />
                 </Grid>
 
                 <Button Content="  i  " Margin="0" HorizontalAlignment="Left" VerticalAlignment="Top" ToolTip="Trigger help" Click="btnInfo_Click" />
-                <TextBlock x:Name="infoText" Margin="0,24" TextWrapping="Wrap" Visibility="Collapsed">
-                    <Run Text="Setting a trigger will play the animation when a game state value (e.g. health) changes or when a keybind is pressed." />
+                <TextBlock x:Name="infoText" Margin="0,20,0,0" TextWrapping="Wrap" Visibility="Collapsed">
+                    <Run Text="• Setting a trigger will play the animation when a game state value (e.g. health) changes or when a keybind is pressed." />
                     <LineBreak />
-                    <Run Text="For 'Always On', the animation does not need a trigger and will run constantly." />
+                    <Run Text="• For 'Always On', the animation does not need a trigger and will run constantly." />
                     <LineBreak />
-                    <Run Text="The stack mode dictates how additional triggers will be handled when an animation is already in progress. 'Ignore' does nothing; 'Restart' restarts the animation and resets repeat count; 'Multiple' will play another copy of the animation in addition to the currently running one." />
+                    <Run Text="• The stack mode dictates how additional triggers will be handled when an animation is already in progress. 'Ignore' does nothing; 'Restart' restarts the animation and resets repeat count; 'Multiple' will play another copy of the animation in addition to the current ones." />
+                    <LineBreak />
+                    <Run Text="• For key-based triggers, the 'Translate to pressed key' option will shift the animation so that the top-left (coords x:0, y:0) become the center of the pressed key, allowing the animation layer to act as a more advanced interactive layer." />
                 </TextBlock>
             </Grid>
         </GroupBox>

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml
@@ -52,13 +52,13 @@
                     <Label Content="Trigger path:" Grid.Row="1" VerticalAlignment="Center" HorizontalAlignment="Right" />
                     <ComboBox x:Name="triggerPath" Grid.Row="1" Grid.Column="1"  Margin="2,4" VerticalAlignment="Center" Height="20" HorizontalAlignment="Stretch" IsEditable="True" TextBoxBase.TextChanged="triggerPath_TextChanged" />
                     <Label Content="Trigger keys:" Grid.Row="2" VerticalAlignment="Top" HorizontalAlignment="Right" />
-                    <CheckBox x:Name="triggerAnyKey" Grid.Row="2" Grid.Column="1" Content="Trigger for any key" Margin="4,6" Checked="triggerAnyKey_Checked" Unchecked="triggerAnyKey_Checked" />
+                    <CheckBox x:Name="triggerAnyKey" Grid.Row="2" Grid.Column="1" Content="Trigger for any key" Margin="-6,6" Checked="triggerAnyKey_Checked" Unchecked="triggerAnyKey_Checked" />
                     <Controls:KeyBindList x:Name="triggerKeys" Margin="0,28,0,0" Grid.Row="2" Grid.Column="1" KeybindsChanged="triggerKeys_KeybindsChanged" />
                     <Label Content="Stack mode:" Grid.Row="4" VerticalAlignment="Center" HorizontalAlignment="Right" />
-                    <CheckBox x:Name="translateToKey" Grid.Row="3" Grid.Column="1" Content="Translate to pressed key" Margin="4,6" Checked="translateToKey_Checked" Unchecked="translateToKey_Checked" />
+                    <CheckBox x:Name="translateToKey" Grid.Row="3" Grid.Column="1" Content="Translate to pressed key" Margin="-6,6" Checked="translateToKey_Checked" Unchecked="translateToKey_Checked" />
                     <TextBlock Text="?" Grid.Row="3" Grid.Column="4" ToolTip="Moves the top-left (0,0) of the animation to the location of the key. When using this option, ensure your animations are centered around 0,0." Cursor="Help" Opacity=".8" TextDecorations="Underline" Margin="12,6" VerticalAlignment="Center" HorizontalAlignment="Right" />
                     <ComboBox x:Name="stackModeCb" Grid.Row="4" Grid.Column="1"  Margin="2,4" VerticalAlignment="Center" HorizontalAlignment="Stretch" SelectionChanged="stackModeCb_SelectionChanged" />
-                    <CheckBox x:Name="whileKeyHeldTerminate" Grid.Row="5" Grid.Column="1" Content="Stop as soon as key released" ToolTip="If true, this setting will stop the animation started by a key press as soon as that key press is released. If false, the animation started by a key will keep going until complete before stopping when the key is released." Margin="4,6" Checked="whileKeyHeldTerminate_Checked" Unchecked="whileKeyHeldTerminate_Checked" />
+                    <CheckBox x:Name="whileKeyHeldTerminate" Grid.Row="5" Grid.Column="1" Content="Stop as soon as key released" ToolTip="If true, this setting will stop the animation started by a key press as soon as that key press is released. If false, the animation started by a key will keep going until complete before stopping when the key is released." Margin="-6,6" Checked="whileKeyHeldTerminate_Checked" Unchecked="whileKeyHeldTerminate_Checked" />
                 </Grid>
 
                 <Button Content="  i  " Margin="0" HorizontalAlignment="Left" VerticalAlignment="Top" ToolTip="Trigger help" Click="btnInfo_Click" />

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml
@@ -29,7 +29,7 @@
             </Grid>
         </GroupBox>
 
-        <GroupBox Header="Trigger" Margin="257,53,0,0" Width="333" Height="269" HorizontalAlignment="Left" VerticalAlignment="Top">
+        <GroupBox Header="Trigger" Margin="257,53,0,0" Width="333" Height="299" HorizontalAlignment="Left" VerticalAlignment="Top">
             <Grid>
                 <Grid x:Name="triggerGridLayout">
                     <Grid.ColumnDefinitions>

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml
@@ -26,7 +26,7 @@
             </Grid>
         </GroupBox>
 
-        <GroupBox Header="Trigger" Margin="257,53,0,0" Width="273" Height="136" HorizontalAlignment="Left" VerticalAlignment="Top">
+        <GroupBox Header="Trigger" Margin="257,53,0,0" Width="273" Height="300" HorizontalAlignment="Left" VerticalAlignment="Top">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="85px" />
@@ -38,6 +38,7 @@
                     <RowDefinition Height="28px" />
                     <RowDefinition Height="28px" />
                     <RowDefinition Height="28px" />
+                    <RowDefinition Height="1*" />
                 </Grid.RowDefinitions>
 
                 <Label Content="Trigger:" Grid.Row="0" VerticalAlignment="Center" HorizontalAlignment="Right" />
@@ -48,6 +49,8 @@
                 <ComboBox x:Name="stackModeCb" Grid.Row="2" Grid.Column="1"  Margin="2,4" VerticalAlignment="Center" HorizontalAlignment="Stretch" SelectionChanged="stackModeCb_SelectionChanged" />
                 <Label Content="Repeat Times:" Grid.Row="3" VerticalAlignment="Center" HorizontalAlignment="Right" />
                 <xctk:IntegerUpDown x:Name="updownAnimationRepeat" Grid.Row="3" Grid.Column="1"  HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="2,4" Value="1" Minimum="1" Maximum="1024" Increment="1" ValueChanged="updownAnimationRepeat_ValueChanged" />
+
+                <TextBlock Text="Setting a trigger will play the animation when a game state value (e.g. health) changes. For 'Always On', the animation does not need a trigger and will run constantly. The stack mode dictates how additional triggers will be handled when an animation is already in progress. 'Ignore' does nothing; 'Restart' restarts the animation and resets repeat count; 'Stack' will play another copy of the animation in addition to the currently running one." TextWrapping="Wrap" Grid.Row="4" Grid.ColumnSpan="2" />
             </Grid>
         </GroupBox>
     </Grid>

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml
@@ -10,11 +10,14 @@
     <Grid>
         <GroupBox Header="Animation" Height="49" Width="530" HorizontalAlignment="Left" VerticalAlignment="Top">
             <Grid>
-                <Button x:Name="btnEditAnimation" Grid.Column="1" Content="Edit Animation" HorizontalAlignment="Left" VerticalAlignment="Top" Click="btnEditAnimation_Click" Width="230" Height="23"/>
+                <Button x:Name="btnEditAnimation" Content="Edit Animation" HorizontalAlignment="Left" VerticalAlignment="Top" Click="btnEditAnimation_Click" Width="116" Height="23"/>
 
-                <Label Content="Animation Duration:" Margin="0,-3,142,0" HorizontalAlignment="Right" VerticalAlignment="Top" Width="118"/>
-                <xctk:DoubleUpDown x:Name="updownAnimationDuration" HorizontalAlignment="Right" Height="20" Margin="0,0,32,0" VerticalAlignment="Top" Width="112" Value="0" Minimum="0.1" Maximum="1024" Increment="0.1" ValueChanged="updownAnimationDuration_ValueChanged" />
-                <Label Content="secs" Margin="0,-3,0,0" HorizontalAlignment="Right" VerticalAlignment="Top"/>
+                <Label Content="Animation Duration:" Margin="0,-1,261,0" HorizontalAlignment="Right" VerticalAlignment="Top" Width="118"/>
+                <xctk:DoubleUpDown x:Name="updownAnimationDuration" HorizontalAlignment="Right" Height="20" Margin="0,2,201,0" VerticalAlignment="Top" Width="60" Value="0" Minimum="0.1" Maximum="1024" Increment="0.1" ValueChanged="updownAnimationDuration_ValueChanged" />
+                <Label Content="secs" Margin="0,-1,169,0" HorizontalAlignment="Right" VerticalAlignment="Top"/>
+
+                <Label Content="Repeat Times:" VerticalAlignment="Center" HorizontalAlignment="Right" Margin="0,-1,68,0" />
+                <xctk:IntegerUpDown x:Name="updownAnimationRepeat" HorizontalAlignment="Right" VerticalAlignment="Top" Margin="0,2,4,0" Width="60" Minimum="0" Maximum="1024" Increment="1" ValueChanged="updownAnimationRepeat_ValueChanged" />
             </Grid>
         </GroupBox>
 
@@ -39,7 +42,6 @@
                         <RowDefinition Height="28px" />
                         <RowDefinition Height="128px" />
                         <RowDefinition Height="28px" />
-                        <RowDefinition Height="28px" />
                         <RowDefinition Height="1*" />
                     </Grid.RowDefinitions>
 
@@ -51,8 +53,6 @@
                     <Controls:KeyBindList x:Name="triggerKeys" Grid.Row="2" Grid.Column="1" KeybindsChanged="triggerKeys_KeybindsChanged" />
                     <Label Content="Stack mode:" Grid.Row="3" VerticalAlignment="Center" HorizontalAlignment="Right" />
                     <ComboBox x:Name="stackModeCb" Grid.Row="3" Grid.Column="1"  Margin="2,4" VerticalAlignment="Center" HorizontalAlignment="Stretch" SelectionChanged="stackModeCb_SelectionChanged" />
-                    <Label Content="Repeat Times:" Grid.Row="4" VerticalAlignment="Center" HorizontalAlignment="Right" />
-                    <xctk:IntegerUpDown x:Name="updownAnimationRepeat" Grid.Row="4" Grid.Column="1"  HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="2,4" Value="1" Minimum="1" Maximum="1024" Increment="1" ValueChanged="updownAnimationRepeat_ValueChanged" />
                 </Grid>
 
                 <Button Content="  i  " Margin="0" HorizontalAlignment="Left" VerticalAlignment="Top" ToolTip="Trigger help" Click="btnInfo_Click" />
@@ -62,8 +62,6 @@
                     <Run Text="For 'Always On', the animation does not need a trigger and will run constantly." />
                     <LineBreak />
                     <Run Text="The stack mode dictates how additional triggers will be handled when an animation is already in progress. 'Ignore' does nothing; 'Restart' restarts the animation and resets repeat count; 'Multiple' will play another copy of the animation in addition to the currently running one." />
-                    <LineBreak />
-                    <Run Text="Repeat Times dictates how many times the animation created will loop for one trigger." />
                 </TextBlock>
             </Grid>
         </GroupBox>

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml
@@ -40,7 +40,7 @@
                     <Grid.RowDefinitions>
                         <RowDefinition Height="28px" />
                         <RowDefinition Height="28px" />
-                        <RowDefinition Height="128px" />
+                        <RowDefinition Height="156px" />
                         <RowDefinition Height="28px" />
                         <RowDefinition Height="1*" />
                     </Grid.RowDefinitions>
@@ -50,7 +50,8 @@
                     <Label Content="Trigger path:" Grid.Row="1" VerticalAlignment="Center" HorizontalAlignment="Right" />
                     <ComboBox x:Name="triggerPath" Grid.Row="1" Grid.Column="1"  Margin="2,4" VerticalAlignment="Center" Height="20" HorizontalAlignment="Stretch" IsEditable="True" TextBoxBase.TextChanged="triggerPath_TextChanged" />
                     <Label Content="Trigger keys:" Grid.Row="2" VerticalAlignment="Top" HorizontalAlignment="Right" />
-                    <Controls:KeyBindList x:Name="triggerKeys" Grid.Row="2" Grid.Column="1" KeybindsChanged="triggerKeys_KeybindsChanged" />
+                    <CheckBox x:Name="triggerAnyKey" Grid.Row="2" Grid.Column="1" Content="Trigger for any key" Margin="4,6" Checked="triggerAnyKey_Checked" Unchecked="triggerAnyKey_Checked" />
+                    <Controls:KeyBindList x:Name="triggerKeys" Margin="0,28,0,0" Grid.Row="2" Grid.Column="1" KeybindsChanged="triggerKeys_KeybindsChanged" />
                     <Label Content="Stack mode:" Grid.Row="3" VerticalAlignment="Center" HorizontalAlignment="Right" />
                     <ComboBox x:Name="stackModeCb" Grid.Row="3" Grid.Column="1"  Margin="2,4" VerticalAlignment="Center" HorizontalAlignment="Stretch" SelectionChanged="stackModeCb_SelectionChanged" />
                 </Grid>

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml
@@ -8,18 +8,47 @@
              xmlns:Controls="clr-namespace:Aurora.Controls" x:Class="Aurora.Settings.Layers.Control_AnimationLayer"
              mc:Ignorable="d" Loaded="UserControl_Loaded">
     <Grid>
-        <Button x:Name="btnEditAnimation" Content="Edit Animation" HorizontalAlignment="Left" VerticalAlignment="Top" Click="btnEditAnimation_Click" Width="85"/>
+        <GroupBox Header="Animation" Height="49" Width="530" HorizontalAlignment="Left" VerticalAlignment="Top">
+            <Grid>
+                <Button x:Name="btnEditAnimation" Grid.Column="1" Content="Edit Animation" HorizontalAlignment="Left" VerticalAlignment="Top" Click="btnEditAnimation_Click" Width="230" Height="23"/>
 
-        <Controls:KeySequence x:Name="KeySequence_keys" Margin="0,69,0,0" HorizontalAlignment="Left" Width="230" RecordingTag="SolidColorLayer" Title="Affected Keys" SequenceUpdated="KeySequence_keys_SequenceUpdated"/>
-        <CheckBox x:Name="chkboxForceKeySequence" Content="Display Only on Key Sequence keys" HorizontalAlignment="Left" Margin="0,27,0,0" VerticalAlignment="Top" Checked="chkboxForceKeySequence_Checked" Unchecked="chkboxForceKeySequence_Checked"/>
-        <CheckBox x:Name="chkboxScaleToKeySequence" Content="Scale to Key Sequence bounds" HorizontalAlignment="Left" Margin="0,48,0,0" VerticalAlignment="Top" Checked="chkboxScaleToKeySequence_Checked" Unchecked="chkboxScaleToKeySequence_Checked"/>
-        <TextBlock HorizontalAlignment="Left" Margin="235,2,0,0" TextWrapping="Wrap" Text="Animation Duration:" VerticalAlignment="Top" Width="107"/>
-        <xctk:DoubleUpDown x:Name="updownAnimationDuration" HorizontalAlignment="Left" Height="20" Margin="347,0,0,0" VerticalAlignment="Top" Width="60" Value="0" Minimum="0" Maximum="1024" Increment="0.1" ValueChanged="updownAnimationDuration_ValueChanged" />
-        <TextBlock HorizontalAlignment="Left" Margin="412,3,0,0" TextWrapping="Wrap" Text="secs" VerticalAlignment="Top"/>
-        <TextBlock HorizontalAlignment="Left" Margin="235,27,0,0" TextWrapping="Wrap" Text="Repeat Animation:" VerticalAlignment="Top" Width="98"/>
-        <xctk:IntegerUpDown x:Name="updownAnimationRepeat" HorizontalAlignment="Left" Height="20" Margin="338,25,0,0" VerticalAlignment="Top" Width="60" Value="0" Minimum="0" Maximum="1024" Increment="1" ValueChanged="updownAnimationRepeat_ValueChanged" />
-        <TextBlock HorizontalAlignment="Left" Margin="403,28,0,0" TextWrapping="Wrap" Text="times" VerticalAlignment="Top"/>
-        <TextBlock HorizontalAlignment="Left" Margin="246,50,0,0" TextWrapping="Wrap" Text="Set to 0 to never stop the animation" VerticalAlignment="Top" FontStyle="Italic" TextDecorations="{x:Null}"/>
+                <Label Content="Animation Duration:" Margin="0,-3,142,0" HorizontalAlignment="Right" VerticalAlignment="Top" Width="118"/>
+                <xctk:DoubleUpDown x:Name="updownAnimationDuration" HorizontalAlignment="Right" Height="20" Margin="0,0,32,0" VerticalAlignment="Top" Width="112" Value="0" Minimum="0" Maximum="1024" Increment="0.1" ValueChanged="updownAnimationDuration_ValueChanged" />
+                <Label Content="secs" Margin="0,-3,0,0" HorizontalAlignment="Right" VerticalAlignment="Top"/>
+            </Grid>
+        </GroupBox>
 
+        <GroupBox Header="Keys" Margin="0,53,0,0" Width="242" HorizontalAlignment="Left">
+            <Grid>
+                <CheckBox x:Name="chkboxForceKeySequence" Content="Display Only on Key Sequence keys" HorizontalAlignment="Left" Margin="0,0,0,0" VerticalAlignment="Top" Checked="chkboxForceKeySequence_Checked" Unchecked="chkboxForceKeySequence_Checked"/>
+                <CheckBox x:Name="chkboxScaleToKeySequence" Content="Scale to Key Sequence bounds" HorizontalAlignment="Left" Margin="0,21,0,0" VerticalAlignment="Top" Checked="chkboxScaleToKeySequence_Checked" Unchecked="chkboxScaleToKeySequence_Checked"/>
+                <Controls:KeySequence x:Name="KeySequence_keys" Margin="0,42,0,0" HorizontalAlignment="Left" Width="230" RecordingTag="SolidColorLayer" Title="Affected Keys" SequenceUpdated="KeySequence_keys_SequenceUpdated"/>
+            </Grid>
+        </GroupBox>
+
+        <GroupBox Header="Trigger" Margin="257,53,0,0" Width="273" Height="136" HorizontalAlignment="Left" VerticalAlignment="Top">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="85px" />
+                    <ColumnDefinition Width="175px" />
+                </Grid.ColumnDefinitions>
+
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="28px" />
+                    <RowDefinition Height="28px" />
+                    <RowDefinition Height="28px" />
+                    <RowDefinition Height="28px" />
+                </Grid.RowDefinitions>
+
+                <Label Content="Trigger:" Grid.Row="0" VerticalAlignment="Center" HorizontalAlignment="Right" />
+                <ComboBox x:Name="triggerModeCb" Grid.Row="0" Grid.Column="1" Margin="2,4" VerticalAlignment="Center" HorizontalAlignment="Stretch" SelectionChanged="triggerMode_SelectionChanged" />
+                <Label Content="Trigger path:" Grid.Row="1" VerticalAlignment="Center" HorizontalAlignment="Right" />
+                <ComboBox x:Name="triggerPath" Grid.Row="1" Grid.Column="1"  Margin="2,4" VerticalAlignment="Center" HorizontalAlignment="Stretch" IsEditable="True" TextBoxBase.TextChanged="triggerPath_TextChanged" />
+                <Label Content="Stack mode:" Grid.Row="2" VerticalAlignment="Center" HorizontalAlignment="Right" />
+                <ComboBox x:Name="stackModeCb" Grid.Row="2" Grid.Column="1"  Margin="2,4" VerticalAlignment="Center" HorizontalAlignment="Stretch" SelectionChanged="stackModeCb_SelectionChanged" />
+                <Label Content="Repeat Times:" Grid.Row="3" VerticalAlignment="Center" HorizontalAlignment="Right" />
+                <xctk:IntegerUpDown x:Name="updownAnimationRepeat" Grid.Row="3" Grid.Column="1"  HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="2,4" Value="1" Minimum="1" Maximum="1024" Increment="1" ValueChanged="updownAnimationRepeat_ValueChanged" />
+            </Grid>
+        </GroupBox>
     </Grid>
 </UserControl>

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml
@@ -8,7 +8,7 @@
              xmlns:Controls="clr-namespace:Aurora.Controls" x:Class="Aurora.Settings.Layers.Control_AnimationLayer"
              mc:Ignorable="d" Loaded="UserControl_Loaded">
     <Grid>
-        <GroupBox Header="Animation" Height="49" Width="550" HorizontalAlignment="Left" VerticalAlignment="Top">
+        <GroupBox Header="Animation" Height="49" Width="590" HorizontalAlignment="Left" VerticalAlignment="Top">
             <Grid>
                 <Button x:Name="btnEditAnimation" Content="Edit Animation" HorizontalAlignment="Left" VerticalAlignment="Top" Click="btnEditAnimation_Click" Width="142" Height="23"/>
 
@@ -29,18 +29,18 @@
             </Grid>
         </GroupBox>
 
-        <GroupBox Header="Trigger" Margin="257,53,0,0" Width="293" Height="316" HorizontalAlignment="Left" VerticalAlignment="Top">
+        <GroupBox Header="Trigger" Margin="257,53,0,0" Width="333" Height="269" HorizontalAlignment="Left" VerticalAlignment="Top">
             <Grid>
                 <Grid x:Name="triggerGridLayout">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="85px" />
-                        <ColumnDefinition Width="195px" />
+                        <ColumnDefinition Width="235px" />
                     </Grid.ColumnDefinitions>
 
                     <Grid.RowDefinitions>
                         <RowDefinition Height="28px" />
                         <RowDefinition Height="28px" />
-                        <RowDefinition Height="156px" />
+                        <RowDefinition Height="160px" />
                         <RowDefinition Height="28px" />
                         <RowDefinition Height="28px" />
                         <RowDefinition Height="28px" />
@@ -53,7 +53,7 @@
                     <ComboBox x:Name="triggerPath" Grid.Row="1" Grid.Column="1"  Margin="2,4" VerticalAlignment="Center" Height="20" HorizontalAlignment="Stretch" IsEditable="True" TextBoxBase.TextChanged="triggerPath_TextChanged" />
                     <Label Content="Trigger keys:" Grid.Row="2" VerticalAlignment="Top" HorizontalAlignment="Right" />
                     <CheckBox x:Name="triggerAnyKey" Grid.Row="2" Grid.Column="1" Content="Trigger for any key" Margin="-6,6" Checked="triggerAnyKey_Checked" Unchecked="triggerAnyKey_Checked" />
-                    <Controls:KeyBindList x:Name="triggerKeys" Margin="0,28,0,0" Grid.Row="2" Grid.Column="1" KeybindsChanged="triggerKeys_KeybindsChanged" />
+                    <Controls:KeySequence x:Name="triggerKeys" Margin="0,28,0,0" Grid.Row="2" Grid.Column="1" RecordingTag="AnimationTriggerKeys" Title="Trigger keys" FreestyleEnabled="False" SequenceUpdated="triggerKeys_SequenceUpdated" />
                     <Label Content="Stack mode:" Grid.Row="4" VerticalAlignment="Center" HorizontalAlignment="Right" />
                     <CheckBox x:Name="translateToKey" Grid.Row="3" Grid.Column="1" Content="Translate to pressed key" Margin="-6,6" Checked="translateToKey_Checked" Unchecked="translateToKey_Checked" />
                     <TextBlock Text="?" Grid.Row="3" Grid.Column="4" ToolTip="Moves the top-left (0,0) of the animation to the location of the key. When using this option, ensure your animations are centered around 0,0." Cursor="Help" Opacity=".8" TextDecorations="Underline" Margin="12,6" VerticalAlignment="Center" HorizontalAlignment="Right" />

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml
@@ -13,7 +13,7 @@
                 <Button x:Name="btnEditAnimation" Grid.Column="1" Content="Edit Animation" HorizontalAlignment="Left" VerticalAlignment="Top" Click="btnEditAnimation_Click" Width="230" Height="23"/>
 
                 <Label Content="Animation Duration:" Margin="0,-3,142,0" HorizontalAlignment="Right" VerticalAlignment="Top" Width="118"/>
-                <xctk:DoubleUpDown x:Name="updownAnimationDuration" HorizontalAlignment="Right" Height="20" Margin="0,0,32,0" VerticalAlignment="Top" Width="112" Value="0" Minimum="0" Maximum="1024" Increment="0.1" ValueChanged="updownAnimationDuration_ValueChanged" />
+                <xctk:DoubleUpDown x:Name="updownAnimationDuration" HorizontalAlignment="Right" Height="20" Margin="0,0,32,0" VerticalAlignment="Top" Width="112" Value="0" Minimum="0.1" Maximum="1024" Increment="0.1" ValueChanged="updownAnimationDuration_ValueChanged" />
                 <Label Content="secs" Margin="0,-3,0,0" HorizontalAlignment="Right" VerticalAlignment="Top"/>
             </Grid>
         </GroupBox>
@@ -43,7 +43,7 @@
                 <Label Content="Trigger:" Grid.Row="0" VerticalAlignment="Center" HorizontalAlignment="Right" />
                 <ComboBox x:Name="triggerModeCb" Grid.Row="0" Grid.Column="1" Margin="2,4" VerticalAlignment="Center" HorizontalAlignment="Stretch" SelectionChanged="triggerMode_SelectionChanged" />
                 <Label Content="Trigger path:" Grid.Row="1" VerticalAlignment="Center" HorizontalAlignment="Right" />
-                <ComboBox x:Name="triggerPath" Grid.Row="1" Grid.Column="1"  Margin="2,4" VerticalAlignment="Center" HorizontalAlignment="Stretch" IsEditable="True" TextBoxBase.TextChanged="triggerPath_TextChanged" />
+                <ComboBox x:Name="triggerPath" Grid.Row="1" Grid.Column="1"  Margin="2,4" VerticalAlignment="Center" Height="20" HorizontalAlignment="Stretch" IsEditable="True" TextBoxBase.TextChanged="triggerPath_TextChanged" />
                 <Label Content="Stack mode:" Grid.Row="2" VerticalAlignment="Center" HorizontalAlignment="Right" />
                 <ComboBox x:Name="stackModeCb" Grid.Row="2" Grid.Column="1"  Margin="2,4" VerticalAlignment="Center" HorizontalAlignment="Stretch" SelectionChanged="stackModeCb_SelectionChanged" />
                 <Label Content="Repeat Times:" Grid.Row="3" VerticalAlignment="Center" HorizontalAlignment="Right" />

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml
@@ -55,6 +55,7 @@
                     <Controls:KeyBindList x:Name="triggerKeys" Margin="0,28,0,0" Grid.Row="2" Grid.Column="1" KeybindsChanged="triggerKeys_KeybindsChanged" />
                     <Label Content="Stack mode:" Grid.Row="4" VerticalAlignment="Center" HorizontalAlignment="Right" />
                     <CheckBox x:Name="translateToKey" Grid.Row="3" Grid.Column="1" Content="Translate to pressed key" Margin="4,6" Checked="translateToKey_Checked" Unchecked="translateToKey_Checked" />
+                    <TextBlock Text="?" Grid.Row="3" Grid.Column="4" ToolTip="Moves the top-left (0,0) of the animation to the location of the key. When using this option, ensure your animations are centered around 0,0." Cursor="Help" Opacity=".8" TextDecorations="Underline" Margin="0,6" VerticalAlignment="Center" HorizontalAlignment="Right" />
                     <ComboBox x:Name="stackModeCb" Grid.Row="4" Grid.Column="1"  Margin="2,4" VerticalAlignment="Center" HorizontalAlignment="Stretch" SelectionChanged="stackModeCb_SelectionChanged" />
                 </Grid>
 

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml
@@ -8,9 +8,9 @@
              xmlns:Controls="clr-namespace:Aurora.Controls" x:Class="Aurora.Settings.Layers.Control_AnimationLayer"
              mc:Ignorable="d" Loaded="UserControl_Loaded">
     <Grid>
-        <GroupBox Header="Animation" Height="49" Width="530" HorizontalAlignment="Left" VerticalAlignment="Top">
+        <GroupBox Header="Animation" Height="49" Width="550" HorizontalAlignment="Left" VerticalAlignment="Top">
             <Grid>
-                <Button x:Name="btnEditAnimation" Content="Edit Animation" HorizontalAlignment="Left" VerticalAlignment="Top" Click="btnEditAnimation_Click" Width="116" Height="23"/>
+                <Button x:Name="btnEditAnimation" Content="Edit Animation" HorizontalAlignment="Left" VerticalAlignment="Top" Click="btnEditAnimation_Click" Width="142" Height="23"/>
 
                 <Label Content="Animation Duration:" Margin="0,-1,261,0" HorizontalAlignment="Right" VerticalAlignment="Top" Width="118"/>
                 <xctk:DoubleUpDown x:Name="updownAnimationDuration" HorizontalAlignment="Right" Height="20" Margin="0,2,201,0" VerticalAlignment="Top" Width="60" Value="0" Minimum="0.1" Maximum="1024" Increment="0.1" ValueChanged="updownAnimationDuration_ValueChanged" />
@@ -29,18 +29,19 @@
             </Grid>
         </GroupBox>
 
-        <GroupBox Header="Trigger" Margin="257,53,0,0" Width="273" Height="306" HorizontalAlignment="Left" VerticalAlignment="Top">
+        <GroupBox Header="Trigger" Margin="257,53,0,0" Width="293" Height="316" HorizontalAlignment="Left" VerticalAlignment="Top">
             <Grid>
                 <Grid x:Name="triggerGridLayout">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="85px" />
-                        <ColumnDefinition Width="175px" />
+                        <ColumnDefinition Width="195px" />
                     </Grid.ColumnDefinitions>
 
                     <Grid.RowDefinitions>
                         <RowDefinition Height="28px" />
                         <RowDefinition Height="28px" />
                         <RowDefinition Height="156px" />
+                        <RowDefinition Height="28px" />
                         <RowDefinition Height="28px" />
                         <RowDefinition Height="28px" />
                         <RowDefinition Height="1*" />
@@ -55,8 +56,9 @@
                     <Controls:KeyBindList x:Name="triggerKeys" Margin="0,28,0,0" Grid.Row="2" Grid.Column="1" KeybindsChanged="triggerKeys_KeybindsChanged" />
                     <Label Content="Stack mode:" Grid.Row="4" VerticalAlignment="Center" HorizontalAlignment="Right" />
                     <CheckBox x:Name="translateToKey" Grid.Row="3" Grid.Column="1" Content="Translate to pressed key" Margin="4,6" Checked="translateToKey_Checked" Unchecked="translateToKey_Checked" />
-                    <TextBlock Text="?" Grid.Row="3" Grid.Column="4" ToolTip="Moves the top-left (0,0) of the animation to the location of the key. When using this option, ensure your animations are centered around 0,0." Cursor="Help" Opacity=".8" TextDecorations="Underline" Margin="0,6" VerticalAlignment="Center" HorizontalAlignment="Right" />
+                    <TextBlock Text="?" Grid.Row="3" Grid.Column="4" ToolTip="Moves the top-left (0,0) of the animation to the location of the key. When using this option, ensure your animations are centered around 0,0." Cursor="Help" Opacity=".8" TextDecorations="Underline" Margin="12,6" VerticalAlignment="Center" HorizontalAlignment="Right" />
                     <ComboBox x:Name="stackModeCb" Grid.Row="4" Grid.Column="1"  Margin="2,4" VerticalAlignment="Center" HorizontalAlignment="Stretch" SelectionChanged="stackModeCb_SelectionChanged" />
+                    <CheckBox x:Name="whileKeyHeldTerminate" Grid.Row="5" Grid.Column="1" Content="Stop as soon as key released" ToolTip="If true, this setting will stop the animation started by a key press as soon as that key press is released. If false, the animation started by a key will keep going until complete before stopping when the key is released." Margin="4,6" Checked="whileKeyHeldTerminate_Checked" Unchecked="whileKeyHeldTerminate_Checked" />
                 </Grid>
 
                 <Button Content="  i  " Margin="0" HorizontalAlignment="Left" VerticalAlignment="Top" ToolTip="Trigger help" Click="btnInfo_Click" />

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml
@@ -28,29 +28,43 @@
 
         <GroupBox Header="Trigger" Margin="257,53,0,0" Width="273" Height="300" HorizontalAlignment="Left" VerticalAlignment="Top">
             <Grid>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="85px" />
-                    <ColumnDefinition Width="175px" />
-                </Grid.ColumnDefinitions>
+                <Grid x:Name="triggerGridLayout">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="85px" />
+                        <ColumnDefinition Width="175px" />
+                    </Grid.ColumnDefinitions>
 
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="28px" />
-                    <RowDefinition Height="28px" />
-                    <RowDefinition Height="28px" />
-                    <RowDefinition Height="28px" />
-                    <RowDefinition Height="1*" />
-                </Grid.RowDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="28px" />
+                        <RowDefinition Height="28px" />
+                        <RowDefinition Height="128px" />
+                        <RowDefinition Height="28px" />
+                        <RowDefinition Height="28px" />
+                        <RowDefinition Height="1*" />
+                    </Grid.RowDefinitions>
 
-                <Label Content="Trigger:" Grid.Row="0" VerticalAlignment="Center" HorizontalAlignment="Right" />
-                <ComboBox x:Name="triggerModeCb" Grid.Row="0" Grid.Column="1" Margin="2,4" VerticalAlignment="Center" HorizontalAlignment="Stretch" SelectionChanged="triggerMode_SelectionChanged" />
-                <Label Content="Trigger path:" Grid.Row="1" VerticalAlignment="Center" HorizontalAlignment="Right" />
-                <ComboBox x:Name="triggerPath" Grid.Row="1" Grid.Column="1"  Margin="2,4" VerticalAlignment="Center" Height="20" HorizontalAlignment="Stretch" IsEditable="True" TextBoxBase.TextChanged="triggerPath_TextChanged" />
-                <Label Content="Stack mode:" Grid.Row="2" VerticalAlignment="Center" HorizontalAlignment="Right" />
-                <ComboBox x:Name="stackModeCb" Grid.Row="2" Grid.Column="1"  Margin="2,4" VerticalAlignment="Center" HorizontalAlignment="Stretch" SelectionChanged="stackModeCb_SelectionChanged" />
-                <Label Content="Repeat Times:" Grid.Row="3" VerticalAlignment="Center" HorizontalAlignment="Right" />
-                <xctk:IntegerUpDown x:Name="updownAnimationRepeat" Grid.Row="3" Grid.Column="1"  HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="2,4" Value="1" Minimum="1" Maximum="1024" Increment="1" ValueChanged="updownAnimationRepeat_ValueChanged" />
+                    <Label Content="Trigger:" Grid.Row="0" VerticalAlignment="Center" HorizontalAlignment="Right" />
+                    <ComboBox x:Name="triggerModeCb" Grid.Row="0" Grid.Column="1" Margin="2,4" VerticalAlignment="Center" HorizontalAlignment="Stretch" SelectionChanged="triggerMode_SelectionChanged" />
+                    <Label Content="Trigger path:" Grid.Row="1" VerticalAlignment="Center" HorizontalAlignment="Right" />
+                    <ComboBox x:Name="triggerPath" Grid.Row="1" Grid.Column="1"  Margin="2,4" VerticalAlignment="Center" Height="20" HorizontalAlignment="Stretch" IsEditable="True" TextBoxBase.TextChanged="triggerPath_TextChanged" />
+                    <Label Content="Trigger keys:" Grid.Row="2" VerticalAlignment="Top" HorizontalAlignment="Right" />
+                    <Controls:KeyBindList x:Name="triggerKeys" Grid.Row="2" Grid.Column="1" KeybindsChanged="triggerKeys_KeybindsChanged" />
+                    <Label Content="Stack mode:" Grid.Row="3" VerticalAlignment="Center" HorizontalAlignment="Right" />
+                    <ComboBox x:Name="stackModeCb" Grid.Row="3" Grid.Column="1"  Margin="2,4" VerticalAlignment="Center" HorizontalAlignment="Stretch" SelectionChanged="stackModeCb_SelectionChanged" />
+                    <Label Content="Repeat Times:" Grid.Row="4" VerticalAlignment="Center" HorizontalAlignment="Right" />
+                    <xctk:IntegerUpDown x:Name="updownAnimationRepeat" Grid.Row="4" Grid.Column="1"  HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="2,4" Value="1" Minimum="1" Maximum="1024" Increment="1" ValueChanged="updownAnimationRepeat_ValueChanged" />
+                </Grid>
 
-                <TextBlock Text="Setting a trigger will play the animation when a game state value (e.g. health) changes. For 'Always On', the animation does not need a trigger and will run constantly. The stack mode dictates how additional triggers will be handled when an animation is already in progress. 'Ignore' does nothing; 'Restart' restarts the animation and resets repeat count; 'Stack' will play another copy of the animation in addition to the currently running one." TextWrapping="Wrap" Grid.Row="4" Grid.ColumnSpan="2" />
+                <Button Content="  i  " Margin="0" HorizontalAlignment="Left" VerticalAlignment="Top" ToolTip="Trigger help" Click="btnInfo_Click" />
+                <TextBlock x:Name="infoText" Margin="0,24" TextWrapping="Wrap" Visibility="Collapsed">
+                    <Run Text="Setting a trigger will play the animation when a game state value (e.g. health) changes or when a keybind is pressed." />
+                    <LineBreak />
+                    <Run Text="For 'Always On', the animation does not need a trigger and will run constantly." />
+                    <LineBreak />
+                    <Run Text="The stack mode dictates how additional triggers will be handled when an animation is already in progress. 'Ignore' does nothing; 'Restart' restarts the animation and resets repeat count; 'Multiple' will play another copy of the animation in addition to the currently running one." />
+                    <LineBreak />
+                    <Run Text="Repeat Times dictates how many times the animation created will loop for one trigger." />
+                </TextBlock>
             </Grid>
         </GroupBox>
     </Grid>

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml.cs
@@ -68,8 +68,10 @@ namespace Aurora.Settings.Layers
                 updownAnimationDuration.Value = (double)Context.Properties._AnimationDuration;
                 updownAnimationRepeat.Value = Context.Properties._AnimationRepeat;
                 triggerModeCb.SelectedIndex = triggerModeCb.Items.SourceCollection.Cast<KeyValuePair<string, AnimationTriggerMode>>().Select((kvp, index) => new { kvp, index }).First(item => item.kvp.Value == Context.Properties.TriggerMode).index;
+                triggerAnyKey.IsChecked = Context.Properties._TriggerAnyKey;
                 triggerPath.Text = Context.Properties._TriggerPath;
                 triggerKeys.Keybinds = Context.Properties._TriggerKeys;
+                translateToKey.IsChecked = Context.Properties._KeyTriggerTranslate;
                 stackModeCb.SelectedIndex = stackModeCb.Items.SourceCollection.Cast<KeyValuePair<string, AnimationStackMode>>().Select((kvp, index) => new { kvp, index }).First(item => item.kvp.Value == Context.Properties.StackMode).index;
                 settingsset = true;
             }
@@ -169,9 +171,10 @@ namespace Aurora.Settings.Layers
             // Only show trigger path when one of the path-like modes is set
             triggerGridLayout.RowDefinitions[1].Height = new GridLength(new[] { AnimationTriggerMode.OnHigh, AnimationTriggerMode.OnLow, AnimationTriggerMode.OnChange }.Contains(selectedItem) ? 28 : 0);
             // Only show tigger keys when one of the key-like modes is set
-            triggerGridLayout.RowDefinitions[2].Height = new GridLength(new[] { AnimationTriggerMode.OnKeyPress, AnimationTriggerMode.OnKeyRelease }.Contains(selectedItem) ? 128 : 0);
+            triggerGridLayout.RowDefinitions[2].Height = new GridLength(selectedItem == AnimationTriggerMode.OnKeyPress || selectedItem == AnimationTriggerMode.OnKeyRelease ? 128 : 0);
+            triggerGridLayout.RowDefinitions[3].Height = new GridLength(selectedItem == AnimationTriggerMode.OnKeyPress || selectedItem == AnimationTriggerMode.OnKeyRelease ? 28 : 0);
             // Only show the stack mode setting if the trigger mode is NOT "AlwaysOn"
-            triggerGridLayout.RowDefinitions[3].Height = new GridLength(selectedItem == AnimationTriggerMode.AlwaysOn ? 0 : 28);
+            triggerGridLayout.RowDefinitions[4].Height = new GridLength(selectedItem == AnimationTriggerMode.AlwaysOn ? 0 : 28);
         }
 
         private void triggerPath_TextChanged(object sender, TextChangedEventArgs e)
@@ -180,9 +183,23 @@ namespace Aurora.Settings.Layers
                 Context.Properties._TriggerPath = (sender as ComboBox).Text;
         }
 
+        private void triggerAnyKey_Checked(object sender, RoutedEventArgs e) {
+            bool val = (sender as CheckBox).IsChecked ?? false;
+            if (CanSet)
+                Context.Properties._TriggerAnyKey = val;
+
+            // Disable keybind box if allow on any keys
+            triggerKeys.IsEnabled = !val;
+        }
+
         private void triggerKeys_KeybindsChanged(object sender) {
             if (CanSet)
                 Context.Properties._TriggerKeys = (sender as KeyBindList).Keybinds;
+        }
+
+        private void translateToKey_Checked(object sender, RoutedEventArgs e) {
+            if (CanSet)
+                Context.Properties._KeyTriggerTranslate = (sender as CheckBox).IsChecked;
         }
 
         private void stackModeCb_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -195,15 +212,6 @@ namespace Aurora.Settings.Layers
             // Toggle the info text textblock and set the triggerGrid visibility to be the opposite
             triggerGridLayout.Visibility = infoText.Visibility;
             infoText.Visibility = infoText.Visibility == Visibility.Visible ? Visibility.Collapsed : Visibility.Visible;
-        }
-
-        private void triggerAnyKey_Checked(object sender, RoutedEventArgs e) {
-            bool val = (sender as CheckBox).IsChecked ?? false;
-            if (CanSet)
-                Context.Properties._TriggerAnyKey = val;
-
-            // Disable keybind box if allow on any keys
-            triggerKeys.IsEnabled = !val;
-        }
+        }        
     }
 }

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml.cs
@@ -196,5 +196,14 @@ namespace Aurora.Settings.Layers
             triggerGridLayout.Visibility = infoText.Visibility;
             infoText.Visibility = infoText.Visibility == Visibility.Visible ? Visibility.Collapsed : Visibility.Visible;
         }
+
+        private void triggerAnyKey_Checked(object sender, RoutedEventArgs e) {
+            bool val = (sender as CheckBox).IsChecked ?? false;
+            if (CanSet)
+                Context.Properties._TriggerAnyKey = val;
+
+            // Disable keybind box if allow on any keys
+            triggerKeys.IsEnabled = !val;
+        }
     }
 }

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Aurora.Utils;
+﻿using Aurora.Controls;
+using Aurora.Utils;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -68,6 +69,7 @@ namespace Aurora.Settings.Layers
                 updownAnimationRepeat.Value = Context.Properties._AnimationRepeat;
                 triggerModeCb.SelectedIndex = triggerModeCb.Items.SourceCollection.Cast<KeyValuePair<string, AnimationTriggerMode>>().Select((kvp, index) => new { kvp, index }).First(item => item.kvp.Value == Context.Properties.TriggerMode).index;
                 triggerPath.Text = Context.Properties._TriggerPath;
+                triggerKeys.Keybinds = Context.Properties._TriggerKeys;
                 stackModeCb.SelectedIndex = stackModeCb.Items.SourceCollection.Cast<KeyValuePair<string, AnimationStackMode>>().Select((kvp, index) => new { kvp, index }).First(item => item.kvp.Value == Context.Properties.StackMode).index;
                 settingsset = true;
             }
@@ -164,8 +166,12 @@ namespace Aurora.Settings.Layers
             if (CanSet)
                 Context.Properties._TriggerMode = selectedItem;
 
-            // Only enable the extra settings if the trigger mode is NOT "AlwaysOn"
-            triggerPath.IsEnabled = stackModeCb.IsEnabled = updownAnimationRepeat.IsEnabled = selectedItem != AnimationTriggerMode.AlwaysOn;
+            // Only show trigger path when one of the path-like modes is set
+            triggerGridLayout.RowDefinitions[1].Height = new GridLength(new[] { AnimationTriggerMode.OnHigh, AnimationTriggerMode.OnLow, AnimationTriggerMode.OnChange }.Contains(selectedItem) ? 28 : 0);
+            // Only show tigger keys when one of the key-like modes is set
+            triggerGridLayout.RowDefinitions[2].Height = new GridLength(new[] { AnimationTriggerMode.OnKeyPress, AnimationTriggerMode.OnKeyRelease }.Contains(selectedItem) ? 128 : 0);
+            // Only show the extra settings if the trigger mode is NOT "AlwaysOn" (Row[3] = Stack Mode, Row[4] = Repeat times)
+            triggerGridLayout.RowDefinitions[3].Height = triggerGridLayout.RowDefinitions[4].Height = new GridLength(selectedItem == AnimationTriggerMode.AlwaysOn ? 0 : 28);
         }
 
         private void triggerPath_TextChanged(object sender, TextChangedEventArgs e)
@@ -174,10 +180,21 @@ namespace Aurora.Settings.Layers
                 Context.Properties._TriggerPath = (sender as ComboBox).Text;
         }
 
+        private void triggerKeys_KeybindsChanged(object sender) {
+            if (CanSet)
+                Context.Properties._TriggerKeys = (sender as KeyBindList).Keybinds;
+        }
+
         private void stackModeCb_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             if (CanSet)
                 Context.Properties._StackMode = ((KeyValuePair<string, AnimationStackMode>)(sender as ComboBox).SelectedItem).Value;
+        }
+
+        private void btnInfo_Click(object sender, RoutedEventArgs e) {
+            // Toggle the info text textblock and set the triggerGrid visibility to be the opposite
+            triggerGridLayout.Visibility = infoText.Visibility;
+            infoText.Visibility = infoText.Visibility == Visibility.Visible ? Visibility.Collapsed : Visibility.Visible;
         }
     }
 }

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml.cs
@@ -170,8 +170,8 @@ namespace Aurora.Settings.Layers
             triggerGridLayout.RowDefinitions[1].Height = new GridLength(new[] { AnimationTriggerMode.OnHigh, AnimationTriggerMode.OnLow, AnimationTriggerMode.OnChange }.Contains(selectedItem) ? 28 : 0);
             // Only show tigger keys when one of the key-like modes is set
             triggerGridLayout.RowDefinitions[2].Height = new GridLength(new[] { AnimationTriggerMode.OnKeyPress, AnimationTriggerMode.OnKeyRelease }.Contains(selectedItem) ? 128 : 0);
-            // Only show the extra settings if the trigger mode is NOT "AlwaysOn" (Row[3] = Stack Mode, Row[4] = Repeat times)
-            triggerGridLayout.RowDefinitions[3].Height = triggerGridLayout.RowDefinitions[4].Height = new GridLength(selectedItem == AnimationTriggerMode.AlwaysOn ? 0 : 28);
+            // Only show the stack mode setting if the trigger mode is NOT "AlwaysOn"
+            triggerGridLayout.RowDefinitions[3].Height = new GridLength(selectedItem == AnimationTriggerMode.AlwaysOn ? 0 : 28);
         }
 
         private void triggerPath_TextChanged(object sender, TextChangedEventArgs e)

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml.cs
@@ -75,6 +75,7 @@ namespace Aurora.Settings.Layers
                 triggerKeys.Keybinds = Context.Properties._TriggerKeys;
                 translateToKey.IsChecked = Context.Properties._KeyTriggerTranslate;
                 stackModeCb.SelectedIndex = stackModeCb.Items.SourceCollection.Cast<KeyValuePair<string, AnimationStackMode>>().Select((kvp, index) => new { kvp, index }).First(item => item.kvp.Value == Context.Properties.StackMode).index;
+                whileKeyHeldTerminate.IsChecked = Context.Properties._WhileKeyHeldTerminateRunning;
                 settingsset = true;
             }
         }
@@ -195,6 +196,8 @@ namespace Aurora.Settings.Layers
             triggerGridLayout.RowDefinitions[3].Height = new GridLength(AnimationLayerHandler.IsTriggerKeyBased(selectedItem) ? 28 : 0);
             // Only show the stack mode setting if the trigger mode is NOT "AlwaysOn"
             triggerGridLayout.RowDefinitions[4].Height = new GridLength(selectedItem == AnimationTriggerMode.AlwaysOn ? 0 : 28);
+            // Only show the force terminate setting if the trigger mode is key press or when key held (not released)
+            triggerGridLayout.RowDefinitions[5].Height = new GridLength(selectedItem == AnimationTriggerMode.OnKeyPress || selectedItem == AnimationTriggerMode.WhileKeyHeld ? 28 : 0);
 
             // Update the combobox
             UpdatePathCombobox();
@@ -235,6 +238,11 @@ namespace Aurora.Settings.Layers
             // Toggle the info text textblock and set the triggerGrid visibility to be the opposite
             triggerGridLayout.Visibility = infoText.Visibility;
             infoText.Visibility = infoText.Visibility == Visibility.Visible ? Visibility.Collapsed : Visibility.Visible;
-        }        
+        }
+
+        private void whileKeyHeldTerminate_Checked(object sender, RoutedEventArgs e) {
+            if (CanSet)
+                Context.Properties._WhileKeyHeldTerminateRunning = (sender as CheckBox).IsChecked;
+        }
     }
 }

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml.cs
@@ -72,7 +72,7 @@ namespace Aurora.Settings.Layers
                 triggerModeCb.SelectedIndex = triggerModeCb.Items.SourceCollection.Cast<KeyValuePair<string, AnimationTriggerMode>>().Select((kvp, index) => new { kvp, index }).First(item => item.kvp.Value == Context.Properties.TriggerMode).index;
                 triggerAnyKey.IsChecked = Context.Properties._TriggerAnyKey;
                 triggerPath.Text = Context.Properties._TriggerPath;
-                triggerKeys.Keybinds = Context.Properties._TriggerKeys;
+                triggerKeys.Sequence = Context.Properties._TriggerKeySequence;
                 translateToKey.IsChecked = Context.Properties._KeyTriggerTranslate;
                 stackModeCb.SelectedIndex = stackModeCb.Items.SourceCollection.Cast<KeyValuePair<string, AnimationStackMode>>().Select((kvp, index) => new { kvp, index }).First(item => item.kvp.Value == Context.Properties.StackMode).index;
                 whileKeyHeldTerminate.IsChecked = Context.Properties._WhileKeyHeldTerminateRunning;
@@ -192,7 +192,7 @@ namespace Aurora.Settings.Layers
             // Only show trigger path when one of the path-like modes is set
             triggerGridLayout.RowDefinitions[1].Height = new GridLength(AnimationLayerHandler.IsTriggerNumericValueBased(selectedItem) || AnimationLayerHandler.IsTriggerBooleanValueBased(selectedItem) ? 28 : 0);
             // Only show tigger keys when one of the key-like modes is set
-            triggerGridLayout.RowDefinitions[2].Height = new GridLength(AnimationLayerHandler.IsTriggerKeyBased(selectedItem) ? 128 : 0);
+            triggerGridLayout.RowDefinitions[2].Height = new GridLength(AnimationLayerHandler.IsTriggerKeyBased(selectedItem) ? 160 : 0);
             triggerGridLayout.RowDefinitions[3].Height = new GridLength(AnimationLayerHandler.IsTriggerKeyBased(selectedItem) ? 28 : 0);
             // Only show the stack mode setting if the trigger mode is NOT "AlwaysOn"
             triggerGridLayout.RowDefinitions[4].Height = new GridLength(selectedItem == AnimationTriggerMode.AlwaysOn ? 0 : 28);
@@ -218,9 +218,9 @@ namespace Aurora.Settings.Layers
             triggerKeys.IsEnabled = !val;
         }
 
-        private void triggerKeys_KeybindsChanged(object sender) {
+        private void triggerKeys_SequenceUpdated(object sender, EventArgs e) {
             if (CanSet)
-                Context.Properties._TriggerKeys = (sender as KeyBindList).Keybinds;
+                Context.Properties._TriggerKeySequence = (sender as Controls.KeySequence).Sequence;
         }
 
         private void translateToKey_Checked(object sender, RoutedEventArgs e) {

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_ComparisonLayer.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_ComparisonLayer.xaml.cs
@@ -43,7 +43,7 @@ namespace Aurora.Settings.Layers {
         public void SetSettings() {
             if (DataContext is ComparisonLayerHandler && !settingsset) {
                 operand1Path.Text = Context.Properties._Operand1Path;
-                @operator.SelectedItem = @operator.Items.SourceCollection.Cast<KeyValuePair<string, ComparisonOperator>>().Where(kvp => kvp.Value == Context.Properties.Operator);
+                @operator.SelectedIndex = @operator.Items.SourceCollection.Cast<KeyValuePair<string, ComparisonOperator>>().Select((kvp, index) => new { kvp, index }).First(item => item.kvp.Value == Context.Properties.Operator).index;
                 operand2Path.Text = Context.Properties._Operand2Path;
                 trueColor.SelectedColor = ColorUtils.DrawingColorToMediaColor(Context.Properties._PrimaryColor ?? System.Drawing.Color.Empty);
                 falseColor.SelectedColor = ColorUtils.DrawingColorToMediaColor(Context.Properties._SecondaryColor ?? System.Drawing.Color.Empty);

--- a/Project-Aurora/Project-Aurora/Utils/GameStateUtils.cs
+++ b/Project-Aurora/Project-Aurora/Utils/GameStateUtils.cs
@@ -177,6 +177,23 @@ namespace Aurora.Utils
             }
         }
 
+        /// <summary>
+        /// Attempts to get a double value from the game state with the given path.
+        /// Returns 0 if an error occures
+        /// </summary>
+        public static double TryGetDoubleFromState(IGameState state, string path) {
+            if (!double.TryParse(path, out double value) && !string.IsNullOrWhiteSpace(path)) {
+                try {
+                    value = Convert.ToDouble(RetrieveGameStateParameter(state, path));
+                } catch (Exception exc) {
+                    value = 0;
+                    if (Global.isDebug)
+                        throw exc;
+                }
+            }
+            return value;
+        }
+
 
         /*public static object RetrieveGameStateParameter(GameState state, string parameter_path, Type type = null)
         {

--- a/Project-Aurora/Project-Aurora/Utils/GameStateUtils.cs
+++ b/Project-Aurora/Project-Aurora/Utils/GameStateUtils.cs
@@ -179,7 +179,7 @@ namespace Aurora.Utils
 
         /// <summary>
         /// Attempts to get a double value from the game state with the given path.
-        /// Returns 0 if an error occures
+        /// Returns 0 if an error occurs
         /// </summary>
         public static double TryGetDoubleFromState(IGameState state, string path) {
             if (!double.TryParse(path, out double value) && !string.IsNullOrWhiteSpace(path)) {
@@ -190,6 +190,20 @@ namespace Aurora.Utils
                     if (Global.isDebug)
                         throw exc;
                 }
+            }
+            return value;
+        }
+
+        /// <summary>
+        /// Attempts to get a boolean value from the game state with the given path.
+        /// Returns false if an error occurs.
+        /// </summary>
+        public static bool TryGetBoolFromState(IGameState state, string path) {
+            bool value = false;
+            if (!string.IsNullOrWhiteSpace(path)) {
+                try {
+                    value = Convert.ToBoolean(RetrieveGameStateParameter(state, path));
+                } catch { }
             }
             return value;
         }


### PR DESCRIPTION
Added a set of trigger options to the animation layer to allow user's to trigger an animation when a particular value in the game state changes. For example, the keyboard could flash red whenever the player takes damage. Original functionality is still available when the trigger is set to "Always On" (default).

### New options:
- The possible trigger values are:
  - Always on (Same as old animation layer functionality)
  - On value increase
  - On value decrease
  - On value change
  - On boolean become true (Plays once when the value changes from false to true)
  - On boolean become false
  - While boolean true (Plays continuously while the value is true)
  - On key pressed (Plays once when the key is pressed)
  - On key released
  - While key held (Plays continuously while the key is held down)
- For the value triggers, the trigger path is the path to the game state variable to watch for changes.
- For the key triggers, either keybinds can be set or any key can be used ("Trigger for any key").
- For key triggers, the animation can be offset to be over the pressed key.
  - If this is turned on, the animation will be shifted so that the top left corner of the animation canvas is at the center of the pressed button.
  - This allows an interactive layer to be created with a custom animation, opening up for loads more customisation!
  - If, for example, you wanted to create a horizontally expanding rectangle from the pressed key, you would add a filled rectangle track, set "Position X" and "Position Y" to 0, the height to something like 5 and with width at 0. Then make another keyframe and set the width to a higher number (still keeping position X and Y at 0). When a key is pressed and "Translate to pressed key" is checked, the center of the rectangle is translated to the location of the key that was pressed.
- Stack mode dictates what should happen if another trigger is fired while an animation is already playing. Can be set to "Ignore", "Restart" or "Multiple". Multiple replays the animation without cancelling or restarting the current one.
- For key triggers in "pressed" or "held" mode (i.e. not "released" mode), an option is added for whether the animation should be terminated immediately. When false, the animation will keep playing until it finishes.

### New UI:
![image](https://user-images.githubusercontent.com/3984322/49292722-f317bb00-f4a5-11e8-86e6-fe96e668b5e4.png)

### YouTube demo:
A demo of the animation firing when taking damage (increasing chassis wear) on Euro Truck Sim.
[![YouTube demo](https://img.youtube.com/vi/GIsC_qCvD0o/0.jpg)](https://www.youtube.com/watch?v=GIsC_qCvD0o)