### PR TITLE
Made "Add profile" use Process Picker

### DIFF
--- a/Project-Aurora/Project-Aurora/ConfigUI.xaml.cs
+++ b/Project-Aurora/Project-Aurora/ConfigUI.xaml.cs
@@ -633,16 +633,11 @@ namespace Aurora
 
         private void AddProfile_MouseDown(object sender, MouseButtonEventArgs e)
         {
-            Microsoft.Win32.OpenFileDialog exe_filedlg = new Microsoft.Win32.OpenFileDialog();
 
-            exe_filedlg.DefaultExt = ".exe";
-            exe_filedlg.Filter = "Executable Files (*.exe)|*.exe;";
+            Window_ProcessSelection dialog = new Window_ProcessSelection { CheckCustomPathExists = true };
+            if (dialog.ShowDialog() == true && !string.IsNullOrWhiteSpace(dialog.ChosenExecutablePath)) { // do not need to check if dialog is already in excluded_programs since it is a Set and only contains unique items by definition
 
-            Nullable<bool> result = exe_filedlg.ShowDialog();
-
-            if (result.HasValue && result == true)
-            {
-                string filename = System.IO.Path.GetFileName(exe_filedlg.FileName.ToLowerInvariant());
+                string filename = Path.GetFileName(dialog.ChosenExecutablePath.ToLowerInvariant());
 
                 if (Global.LightingStateManager.Events.ContainsKey(filename))
                 {
@@ -659,10 +654,10 @@ namespace Aurora
                 gen_app_pm.Initialize();
                 ((GenericApplicationSettings)gen_app_pm.Settings).ApplicationName = Path.GetFileNameWithoutExtension(filename);
 
-                System.Drawing.Icon ico = System.Drawing.Icon.ExtractAssociatedIcon(exe_filedlg.FileName.ToLowerInvariant());
+                System.Drawing.Icon ico = System.Drawing.Icon.ExtractAssociatedIcon(dialog.ChosenExecutablePath.ToLowerInvariant());
 
-                if (!System.IO.Directory.Exists(gen_app_pm.GetProfileFolderPath()))
-                    System.IO.Directory.CreateDirectory(gen_app_pm.GetProfileFolderPath());
+                if (!Directory.Exists(gen_app_pm.GetProfileFolderPath()))
+                    Directory.CreateDirectory(gen_app_pm.GetProfileFolderPath());
 
                 using (var icon_asbitmap = ico.ToBitmap())
                 {

--- a/Project-Aurora/Project-Aurora/Settings/Control_Settings.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Control_Settings.xaml.cs
@@ -405,9 +405,9 @@ namespace Aurora.Settings
 
         private void excluded_add_Click(object sender, RoutedEventArgs e)
         {
-            Window_ProcessSelection dialog = new Window_ProcessSelection();
-            if (dialog.ShowDialog() == true && !String.IsNullOrWhiteSpace(dialog.ChosenExecutable)) // do not need to check if dialog is already in excluded_programs since it is a Set and only contains unique items by definition
-                Global.Configuration.excluded_programs.Add(dialog.ChosenExecutable);
+            Window_ProcessSelection dialog = new Window_ProcessSelection { ButtonLabel = "Exclude Process" };
+            if (dialog.ShowDialog() == true && !string.IsNullOrWhiteSpace(dialog.ChosenExecutableName)) // do not need to check if dialog is already in excluded_programs since it is a Set and only contains unique items by definition
+                Global.Configuration.excluded_programs.Add(dialog.ChosenExecutableName);
 
             load_excluded_listbox();
         }

--- a/Project-Aurora/Project-Aurora/Settings/Window_ProcessSelection.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Window_ProcessSelection.xaml
@@ -87,7 +87,7 @@
         </TabControl>
 
         <StackPanel Orientation="Horizontal" Grid.Row="1" HorizontalAlignment="Right" Margin="0,10">
-            <Button Content="Exclude process" Padding="5,0" Click="OkayButton_Click" IsDefault="True" />
+            <Button x:Name="okayButton" Content="Select process" Padding="5,0" Click="OkayButton_Click" IsDefault="True" />
             <Button Content="Cancel" Margin="10,0" Padding="5,0" Click="CancelButton_Click" IsCancel="True" />
         </StackPanel>
     </Grid>


### PR DESCRIPTION
 Made the add profile button use the process picker selection dialog.

Process selection dialog browse dialog now has a `*.*` filter to allow non-exes to be added (resolves #1339). Has been tested with Red Alert 3 Uprising's `.game` file (does not use `.exe`).

Process selection dialog now also has the option to change okay button label, can return full path of selected process and can require file validation on the text from the browse for process tab text box.