### PR TITLE
Wrapper layer key cloning

### DIFF
--- a/Project-Aurora/Project-Aurora/Controls/KeySequence.xaml
+++ b/Project-Aurora/Project-Aurora/Controls/KeySequence.xaml
@@ -29,7 +29,7 @@
                 </Label.Resources>
             </Label>
             <Grid DockPanel.Dock="Bottom">
-                <ListBox x:Name="keys_keysequence" Margin="0,0,80,25" ItemTemplate="{Binding Source={StaticResource DeviceKeys}}" MinWidth="150"  SelectionMode="Multiple" SelectionChanged="keys_keysequence_SelectionChanged" VerticalAlignment="Stretch"/>
+                <ListBox x:Name="keys_keysequence" Margin="0,0,80,25" ItemTemplate="{Binding Source={StaticResource DeviceKeys}}" MinWidth="150" SelectionMode="Extended" SelectionChanged="keys_keysequence_SelectionChanged" VerticalAlignment="Stretch"/>
                 <Button x:Name="sequence_up" Margin="0,50,40,0" VerticalAlignment="Top" Click="sequence_up_keys_Click" HorizontalAlignment="Right" Width="35">&#x2191;</Button>
                 <Button x:Name="sequence_down" HorizontalAlignment="Right" Margin="0,50,0,0" VerticalAlignment="Top" Width="35" Click="sequence_down_keys_Click">&#x2193;</Button>
                 <Button x:Name="sequence_remove" Content="Remove" Margin="0,25,0,0" VerticalAlignment="Top" Click="sequence_remove_keys_Click" HorizontalAlignment="Right" Width="75"/>

--- a/Project-Aurora/Project-Aurora/Controls/KeySequence.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Controls/KeySequence.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
@@ -53,8 +54,10 @@ namespace Aurora.Controls
             {
                 if (Sequence == null)
                     Sequence = new Settings.KeySequence(value.ToArray());
-                else
+                else {
                     Sequence.keys = value;
+                }
+                SequenceKeysChange?.Invoke(this, new EventArgs());
             }
         }
         private bool allowListRefresh = true;
@@ -96,6 +99,8 @@ namespace Aurora.Controls
             }
         }
 
+        public IEnumerable<Devices.DeviceKeys> SelectedItems => keys_keysequence.SelectedItems.Cast<Devices.DeviceKeys>();
+
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public static readonly DependencyProperty FreestyleEnabledProperty = DependencyProperty.Register("FreestyleEnabled", typeof(bool), typeof(UserControl));
 
@@ -115,7 +120,11 @@ namespace Aurora.Controls
             }
         }
 
+        /// <summary>Fired whenever the KeySequence object is changed or re-created. Does NOT trigger when keys are changed.</summary>
         public event EventHandler SequenceUpdated;
+        /// <summary>Fired whenever keys are changed.</summary>
+        public event EventHandler SequenceKeysChange;
+        public event SelectionChangedEventHandler SelectionChanged;
 
         public KeySequence()
         {
@@ -305,6 +314,9 @@ namespace Aurora.Controls
                 this.sequence_up.IsEnabled = IsEnabled && false;
                 this.sequence_down.IsEnabled = IsEnabled && false;
             }
+
+            // Bubble the selection changed event
+            SelectionChanged?.Invoke(this, e);
         }
 
         private void UserControl_IsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)

--- a/Project-Aurora/Project-Aurora/Profiles/LightingStateManager.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/LightingStateManager.cs
@@ -627,7 +627,7 @@ namespace Aurora.Profiles
             {
                 profile = tempProfile;
                 preview = true;
-            } else if (Global.Configuration.allow_wrappers_in_background && Global.net_listener != null && Global.net_listener.IsWrapperConnected && ((tempProfile = GetProfileFromProcessName(Global.net_listener.WrappedProcess)) != null) && tempProfile.Config.Type == LightEventType.Normal && tempProfile.Config.ProcessNames.Contains(process_name) && tempProfile.IsEnabled)
+            } else if (Global.Configuration.allow_wrappers_in_background && Global.net_listener != null && Global.net_listener.IsWrapperConnected && ((tempProfile = GetProfileFromProcessName(Global.net_listener.WrappedProcess)) != null) && tempProfile.Config.Type == LightEventType.Normal && tempProfile.IsEnabled)
                 profile = tempProfile;
 
             profile = profile ?? DesktopProfile;

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_WrapperLightsLayer.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_WrapperLightsLayer.xaml
@@ -9,23 +9,47 @@
              mc:Ignorable="d" Loaded="UserControl_Loaded">
     <Grid>
         <TextBlock TextWrapping="Wrap" Text="The purpose of this layer is to display lighting effects from games that have native lighting(LightFX, Razer, Logitech, etc) that Aurora has wrappers for. This will only work if you have a wrapper applied to the correct location for a game that supports the lighting engine that the wrapper is designed for." HorizontalAlignment="Left" Width="487" VerticalAlignment="Top" Margin="0,0,0,0"/>
-        <Grid Margin="0,69,0,0">
-            <CheckBox x:Name="ce_enabled" Content="Enable Color Enhancing" HorizontalAlignment="Left" Margin="0" VerticalAlignment="Top" IsChecked="{Binding Properties._ColorEnhanceEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
-            <TextBlock Text="Color Enhancing Mode:" Margin="10,23,0,0" VerticalAlignment="Top" HorizontalAlignment="Left"/>
-            <ComboBox x:Name="ce_mode" HorizontalAlignment="Left" Margin="139,20,0,0" VerticalAlignment="Top" Width="120" SelectedIndex="{Binding Properties._ColorEnhanceMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
-                <ComboBoxItem Content="Linear"/>
-                <ComboBoxItem Content="HSV"/>
-            </ComboBox>
-            <TextBlock HorizontalAlignment="Left" Margin="10,47,0,0" TextWrapping="Wrap" Text="Color Factor:" VerticalAlignment="Top"/>
-            <Slider x:Name="ce_color_factor" HorizontalAlignment="Left" Margin="116,47,0,0" VerticalAlignment="Top" Width="200" Minimum="1" Maximum="255" Value="{Binding Properties._ColorEnhanceColorFactor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ValueChanged="ce_color_factor_ValueChanged"/>
-            <TextBlock x:Name="ce_color_factor_label" HorizontalAlignment="Left" Margin="321,47,0,0" TextWrapping="Wrap" Text="255" VerticalAlignment="Top"/>
-            <TextBlock HorizontalAlignment="Left" Margin="10,70,0,0" TextWrapping="Wrap" Text="HSV Sine Factor:" VerticalAlignment="Top" ToolTip="Changes the factor on how much the sine applies to the Formula, which makes darker colors brighter and bright colors darker. Higher values have a greater impact."/>
-            <Slider x:Name="ce_color_hsv_sine" HorizontalAlignment="Left" Margin="116,70,0,0" VerticalAlignment="Top" Width="200" Minimum="0.0" Maximum="0.16" Value="{Binding Properties._ColorEnhanceColorHSVSine, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ValueChanged="ce_color_hsv_sine_ValueChanged" IsSnapToTickEnabled="True" TickFrequency="0.02"/>
-            <TextBlock x:Name="ce_color_hsv_sine_label" HorizontalAlignment="Left" Margin="325,70,0,0" TextWrapping="Wrap" Text="0.1" VerticalAlignment="Top"/>
-            <TextBlock HorizontalAlignment="Left" Margin="10,93,0,0" TextWrapping="Wrap" Text="HSV Gamma Value:" VerticalAlignment="Top" ToolTip="Changes the factor for overall stronger colors. It cancels out the effect of the option above in the upper half of the brightness spectrum."/>
-            <Slider x:Name="ce_color_hsv_gamma" HorizontalAlignment="Left" Margin="116,93,0,0" VerticalAlignment="Top" Width="200" Minimum="1.0" Maximum="4.0" Value="{Binding Properties._ColorEnhanceColorHSVGamma, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ValueChanged="ce_color_hsv_gamma_ValueChanged" IsSnapToTickEnabled="True" TickFrequency="0.05"/>
-            <TextBlock x:Name="ce_color_hsv_gamma_label" HorizontalAlignment="Left" Margin="325,93,0,0" TextWrapping="Wrap" Text="1.5" VerticalAlignment="Top"/>
-            <TextBlock TextWrapping="Wrap" Text="HSV is an algorithm to brighten dark colors, while not affecting bright colors in an elegant way. To do this, it needs more calculations per color, therefore uses more CPU power. If you notice any delays, you should consider not using HSV." Margin="27,133,0,0" HorizontalAlignment="Left" Width="314" VerticalAlignment="Top" FontStyle="Italic"/>
-        </Grid>
+
+        <GroupBox Header="Color Enhancement" Margin="0,69,0,0" Width="358" HorizontalAlignment="Left" VerticalAlignment="Top">
+            <Grid>
+                <CheckBox x:Name="ce_enabled" Content="Enable" HorizontalAlignment="Left" Margin="10,7,0,0" VerticalAlignment="Top" IsChecked="{Binding Properties._ColorEnhanceEnabled, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                <TextBlock Text="Color Enhancing Mode:" Margin="10,29,-41,0" VerticalAlignment="Top" HorizontalAlignment="Left" Grid.RowSpan="2"/>
+                <ComboBox x:Name="ce_mode" HorizontalAlignment="Left" Margin="139,26,-166,0" VerticalAlignment="Top" Width="120" SelectedIndex="{Binding Properties._ColorEnhanceMode, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Grid.RowSpan="2">
+                    <ComboBoxItem Content="Linear"/>
+                    <ComboBoxItem Content="HSV"/>
+                </ComboBox>
+                <TextBlock HorizontalAlignment="Left" Margin="10,53,0,0" TextWrapping="Wrap" Text="Color Factor:" VerticalAlignment="Top" Grid.RowSpan="2"/>
+                <Slider x:Name="ce_color_factor" HorizontalAlignment="Left" Margin="116,53,-223,0" VerticalAlignment="Top" Width="200" Minimum="1" Maximum="255" Value="{Binding Properties._ColorEnhanceColorFactor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ValueChanged="ce_color_factor_ValueChanged" Grid.RowSpan="2"/>
+                <TextBlock x:Name="ce_color_factor_label" HorizontalAlignment="Left" Margin="321,53,-235,0" TextWrapping="Wrap" Text="255" VerticalAlignment="Top" Grid.RowSpan="2"/>
+                <TextBlock HorizontalAlignment="Left" Margin="10,76,0,0" TextWrapping="Wrap" Text="HSV Sine Factor:" VerticalAlignment="Top" ToolTip="Changes the factor on how much the sine applies to the Formula, which makes darker colors brighter and bright colors darker. Higher values have a greater impact." Grid.RowSpan="2"/>
+                <Slider x:Name="ce_color_hsv_sine" HorizontalAlignment="Left" Margin="116,76,-223,0" VerticalAlignment="Top" Width="200" Minimum="0.0" Maximum="0.16" Value="{Binding Properties._ColorEnhanceColorHSVSine, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ValueChanged="ce_color_hsv_sine_ValueChanged" IsSnapToTickEnabled="True" TickFrequency="0.02" Grid.RowSpan="2"/>
+                <TextBlock x:Name="ce_color_hsv_sine_label" HorizontalAlignment="Left" Margin="325,76,-239,0" TextWrapping="Wrap" Text="0.1" VerticalAlignment="Top" Grid.RowSpan="2"/>
+                <TextBlock HorizontalAlignment="Left" Margin="10,99,0,0" TextWrapping="Wrap" Text="HSV Gamma Value:" VerticalAlignment="Top" ToolTip="Changes the factor for overall stronger colors. It cancels out the effect of the option above in the upper half of the brightness spectrum." Grid.RowSpan="2"/>
+                <Slider x:Name="ce_color_hsv_gamma" HorizontalAlignment="Left" Margin="116,99,-223,0" VerticalAlignment="Top" Width="200" Minimum="1.0" Maximum="4.0" Value="{Binding Properties._ColorEnhanceColorHSVGamma, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ValueChanged="ce_color_hsv_gamma_ValueChanged" IsSnapToTickEnabled="True" TickFrequency="0.05" Grid.RowSpan="2"/>
+                <TextBlock x:Name="ce_color_hsv_gamma_label" HorizontalAlignment="Left" Margin="325,99,-239,0" TextWrapping="Wrap" Text="1.5" VerticalAlignment="Top" Grid.RowSpan="2"/>
+                <TextBlock TextWrapping="Wrap" Text="HSV is an algorithm to brighten dark colors, while not affecting bright colors in an elegant way. To do this, it needs more calculations per color, therefore uses more CPU power. If you notice any delays, you should consider not using HSV." Margin="27,139,-248,0" HorizontalAlignment="Left" Width="314" VerticalAlignment="Top" FontStyle="Italic" Grid.RowSpan="2"/>
+            </Grid>
+        </GroupBox>
+
+        <GroupBox Header="Key Cloning" Margin="368,69,0,0" HorizontalAlignment="Left" Height="228" VerticalAlignment="Top">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="230" />
+                    <ColumnDefinition Width="12px" />
+                    <ColumnDefinition Width="230" />
+                </Grid.ColumnDefinitions>
+
+                <TextBlock Text="Key cloning allows the wrapper layer to take the value that would be applied to a key (the source key) and apply it to one or more other keys (destination keys) as well." TextWrapping="Wrap" Margin="6,0" Grid.ColumnSpan="3" />
+
+                <Label Content="Source Keys:" Grid.Column="0" Margin="0,32,0,0" />
+                <!--<ListBox Grid.Column="0" Margin="0,57,80,0" MinWidth="150" VerticalAlignment="Stretch" />
+                <Button Content="Add key" Margin="0,57,0,0" VerticalAlignment="Top" HorizontalAlignment="Right" Width="75" />
+                <Button Content="Remove" Margin="0,84,0,0" VerticalAlignment="Top" HorizontalAlignment="Right" Width="75" />-->
+                <Controls:KeySequence x:Name="CloneSourceKS" Grid.Column="0" Margin="0,57,0,0" FreestyleEnabled="False" Title="Source Keys" RecordingTag="WrapperCloneSource" SequenceKeysChange="CloneSourceKS_SequenceKeysChange" SelectionChanged="CloneSourceKS_SelectionChanged" />
+
+                <Label Content="Desination Keys:" Grid.Column="2" Margin="0,32,0,0" />
+                <Controls:KeySequence x:Name="CloneDestKS" Grid.Column="2" Margin="0,57,0,0" IsEnabled="False" Title="Destination Keys" RecordingTag="WrapperCloneDestination" SequenceKeysChange="CloneDestKS_SequenceKeysChange" />
+            </Grid>
+        </GroupBox>
     </Grid>
 </UserControl>

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_WrapperLightsLayer.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_WrapperLightsLayer.xaml.cs
@@ -27,17 +27,18 @@ namespace Aurora.Settings.Layers
             InitializeComponent();
         }
 
-        public Control_WrapperLightsLayer(WrapperLightsLayerHandler datacontext)
+        public Control_WrapperLightsLayer(WrapperLightsLayerHandler datacontext) : this()
         {
-            InitializeComponent();
-
             this.DataContext = datacontext;
         }
+
+        private WrapperLightsLayerHandler Context => DataContext as WrapperLightsLayerHandler;
 
         public void SetSettings()
         {
             if(this.DataContext is WrapperLightsLayerHandler && !settingsset)
             {
+                CloneSourceKS.Sequence = new KeySequence(Context.Properties._CloningMap.Keys.ToArray());
                 settingsset = true;
             }
         }
@@ -45,7 +46,6 @@ namespace Aurora.Settings.Layers
         private void UserControl_Loaded(object sender, RoutedEventArgs e)
         {
             SetSettings();
-
             this.Loaded -= UserControl_Loaded;
         }
 
@@ -65,6 +65,31 @@ namespace Aurora.Settings.Layers
         {
             if (IsLoaded)
                 this.ce_color_hsv_gamma_label.Text = ((float)this.ce_color_hsv_gamma.Value).ToString();
+        }
+
+        private void CloneSourceKS_SequenceKeysChange(object sender, EventArgs e) {
+            // If any items ARE in the clone map but NOT in the sequence, remove them
+            // We dont need to worry about adding items to the clone map since CloneDestKS_SequenceUpdated takes care of that
+            var toRemove = Context.Properties.CloningMap.Keys.Where(key => !CloneSourceKS.Sequence.keys.Contains(key)).ToList();
+            foreach (var key in toRemove)
+                Context.Properties.CloningMap.Remove(key);
+        }
+
+        private void CloneDestKS_SequenceKeysChange(object sender, EventArgs e) {
+            // Adds or updates the sequnce in the cloning map at the source key
+            if (CloneSourceKS.SelectedItems.Count() == 1)
+                Context.Properties.CloningMap[CloneSourceKS.SelectedItems.First()] = CloneDestKS.Sequence;
+        }
+
+        private void CloneSourceKS_SelectionChanged(object sender, SelectionChangedEventArgs e) {
+            int selectedCount = CloneSourceKS.SelectedItems.Count();
+            // The destination can only be edited for one source at a time
+            CloneDestKS.IsEnabled = selectedCount == 1;
+
+            // Set the destination sequence to be the sequence from the cloning map if a sequence for the source key exists
+            CloneDestKS.Sequence = selectedCount == 1 && Context.Properties.CloningMap.ContainsKey(CloneSourceKS.SelectedItems.First())
+                ? Context.Properties.CloningMap[CloneSourceKS.SelectedItems.First()]
+                : null;
         }
     }
 }

--- a/Project-Aurora/Project-Aurora/Settings/Layers/WrapperLightsLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/WrapperLightsLayerHandler.cs
@@ -6,6 +6,7 @@ using System.Drawing;
 using Aurora.Profiles;
 using System.Windows.Controls;
 using Newtonsoft.Json;
+using Aurora.Devices;
 
 namespace Aurora.Settings.Layers
 {
@@ -32,15 +33,14 @@ namespace Aurora.Settings.Layers
         [JsonIgnore]
         public float ColorEnhanceColorHSVGamma { get { return Logic._ColorEnhanceColorHSVGamma ?? _ColorEnhanceColorHSVGamma ?? 0.0f; } }
 
-        public WrapperLightsLayerHandlerProperties() : base()
-        {
+        // Key cloning
+        [JsonIgnore]
+        public Dictionary<DeviceKeys, KeySequence> CloningMap => Logic._CloningMap ?? _CloningMap ?? new Dictionary<DeviceKeys, KeySequence>();
+        public Dictionary<DeviceKeys, KeySequence> _CloningMap { get; set; }
 
-        }
+        public WrapperLightsLayerHandlerProperties() : base() { }
 
-        public WrapperLightsLayerHandlerProperties(bool arg = false) : base(arg)
-        {
-
-        }
+        public WrapperLightsLayerHandlerProperties(bool arg = false) : base(arg) { }
 
         public override void Default()
         {
@@ -52,6 +52,7 @@ namespace Aurora.Settings.Layers
             _ColorEnhanceColorFactor = 90;
             _ColorEnhanceColorHSVSine = 0.1f;
             _ColorEnhanceColorHSVGamma = 2.5f;
+            _CloningMap = new Dictionary<DeviceKeys, KeySequence>();
         }
     }
 
@@ -91,14 +92,25 @@ namespace Aurora.Settings.Layers
             Devices.DeviceKeys[] allkeys = Enum.GetValues(typeof(Devices.DeviceKeys)).Cast<Devices.DeviceKeys>().ToArray();
             foreach (var key in allkeys)
             {
-                if(extra_keys.ContainsKey(key))
+                if (extra_keys.ContainsKey(key))
+                {
                     bitmap_layer.Set(key, GetBoostedColor(extra_keys[key]));
+
+                    // Do the key cloning
+                    if (Properties.CloningMap.ContainsKey(key))
+                        bitmap_layer.Set(Properties.CloningMap[key], GetBoostedColor(extra_keys[key]));
+                }
                 else
                 {
                     Devices.Logitech.Logitech_keyboardBitmapKeys logi_key = Devices.Logitech.LogitechDevice.ToLogitechBitmap(key);
 
-                    if (logi_key != Devices.Logitech.Logitech_keyboardBitmapKeys.UNKNOWN && bitmap.Length > 0)
+                    if (logi_key != Devices.Logitech.Logitech_keyboardBitmapKeys.UNKNOWN && bitmap.Length > 0) {
                         bitmap_layer.Set(key, GetBoostedColor(Utils.ColorUtils.GetColorFromInt(bitmap[(int)logi_key / 4])));
+
+                        // Key cloning
+                        if (Properties.CloningMap.ContainsKey(key))
+                            bitmap_layer.Set(Properties.CloningMap[key], GetBoostedColor(Utils.ColorUtils.GetColorFromInt(bitmap[(int)logi_key / 4])));
+                    }
                 }
             }
 

--- a/Project-Aurora/Project-Aurora/Settings/Layers/WrapperLightsLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/WrapperLightsLayerHandler.cs
@@ -92,6 +92,13 @@ namespace Aurora.Settings.Layers
             Devices.DeviceKeys[] allkeys = Enum.GetValues(typeof(Devices.DeviceKeys)).Cast<Devices.DeviceKeys>().ToArray();
             foreach (var key in allkeys)
             {
+
+                // This checks if a key is already being cloned over and thus should be prevented from being re-set by the
+                // normal wrapper. Fixes issues with some clones not working. Thanks to @Gurjot95 for finding it :)
+                if (Properties.CloningMap.Values.Any(sequence => sequence.keys.Contains(key)))
+                    continue;
+
+
                 if (extra_keys.ContainsKey(key))
                 {
                     bitmap_layer.Set(key, GetBoostedColor(extra_keys[key]));
@@ -105,11 +112,12 @@ namespace Aurora.Settings.Layers
                     Devices.Logitech.Logitech_keyboardBitmapKeys logi_key = Devices.Logitech.LogitechDevice.ToLogitechBitmap(key);
 
                     if (logi_key != Devices.Logitech.Logitech_keyboardBitmapKeys.UNKNOWN && bitmap.Length > 0) {
-                        bitmap_layer.Set(key, GetBoostedColor(Utils.ColorUtils.GetColorFromInt(bitmap[(int)logi_key / 4])));
+                        var color = GetBoostedColor(Utils.ColorUtils.GetColorFromInt(bitmap[(int)logi_key / 4]));
+                        bitmap_layer.Set(key, color);
 
                         // Key cloning
                         if (Properties.CloningMap.ContainsKey(key))
-                            bitmap_layer.Set(Properties.CloningMap[key], GetBoostedColor(Utils.ColorUtils.GetColorFromInt(bitmap[(int)logi_key / 4])));
+                            bitmap_layer.Set(Properties.CloningMap[key], color);
                     }
                 }
             }


### PR DESCRIPTION
Adds an option to the wrapper layer to allow keys to be cloned. This involves taking the color from a source key and applying it to one or more destination keys. There can be multiple source keys each with their own set of destination keys.

Also quick fix for the "Allow Aurora wrappers to take priority over desktop profile" checkbox so it works as intended.

Thanks to @Gurjot95 for the help with this!