### PR TITLE
Added HTTP GSI request viewer (for debug)

### DIFF
--- a/Project-Aurora/Project-Aurora/Project-Aurora.csproj
+++ b/Project-Aurora/Project-Aurora/Project-Aurora.csproj
@@ -569,6 +569,9 @@
       <DependentUpon>Control_ROTTombRaider.xaml</DependentUpon>
     </Compile>
     <Compile Include="Profiles\ROT Tomb Raider\ROTTombRaiderApplication.cs" />
+    <Compile Include="Settings\Window_GSIHttpDebug.xaml.cs">
+      <DependentUpon>Window_GSIHttpDebug.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Settings\Window_ProcessSelection.xaml.cs">
       <DependentUpon>Window_ProcessSelection.xaml</DependentUpon>
     </Compile>
@@ -1875,6 +1878,10 @@
     <Page Include="Settings\Layers\Control_SolidColorLayer.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Settings\Window_GSIHttpDebug.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Settings\Window_LayerLogicEditor.xaml">
       <SubType>Designer</SubType>

--- a/Project-Aurora/Project-Aurora/Settings/Control_Settings.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Control_Settings.xaml
@@ -293,6 +293,7 @@
                     <Image x:Name="debug_bitmap_preview" HorizontalAlignment="Left" Margin="152,10,0,0" VerticalAlignment="Top" MaxWidth="400" MaxHeight="400"/>
                     <Button x:Name="btnShowBitmapWindow" Content="Show Bitmap Window" HorizontalAlignment="Left" Margin="10,31,0,0" VerticalAlignment="Top" Click="btnShowBitmapWindow_Click"/>
                     <Button x:Name="btnShowLogsFolder" Content="Show Logs Folder" HorizontalAlignment="Left" Margin="10,56,0,0" VerticalAlignment="Top" Click="btnShowLogsFolder_Click"/>
+                    <Button x:Name="btnShowGSILog" Content="Show GSI HTTP requests" HorizontalAlignment="Left" Margin="10,81,0,0" VerticalAlignment="Top" Click="btnShowGSILog_Click" />
                     <Button Content="Record" HorizontalAlignment="Left" Margin="10,81,0,0" VerticalAlignment="Top" Width="75" Click="Button_Click" IsEnabled="False" Visibility="Collapsed"/>
                 </Grid>
             </TabItem>

--- a/Project-Aurora/Project-Aurora/Settings/Control_Settings.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Control_Settings.xaml.cs
@@ -1057,5 +1057,7 @@ namespace Aurora.Settings
         {
             Process.GetCurrentProcess().PriorityClass = Global.Configuration.HighPriority ? ProcessPriorityClass.High : ProcessPriorityClass.Normal;
         }
+
+        private void btnShowGSILog_Click(object sender, RoutedEventArgs e) => new Window_GSIHttpDebug().Show();
     }
 }

--- a/Project-Aurora/Project-Aurora/Settings/Window_GSIHttpDebug.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Window_GSIHttpDebug.xaml
@@ -7,21 +7,18 @@
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800"
              Title="Aurora Game State Integration HTTP Request Viewer"
-             Loaded="Window_Loaded" Closing="Window_Closing">
+             Loaded="Window_Loaded" Closing="Window_Closing" Background="#181818">
     <Grid>
-        <RichTextBox x:Name="BodyPreviewTxt" IsReadOnly="True" Background="#1E1E1E" BorderThickness="0" Padding="4px">
-            <RichTextBox.Resources>
-                <Style TargetType="{x:Type FlowDocument}">
-                    <Setter Property="FontFamily" Value="Fira Code,Consolas,Courier New,monospace" />
-                    <Setter Property="FontSize" Value="12" />
-                    <Setter Property="Foreground" Value="#C9D1CE" />
-                </Style>
-            </RichTextBox.Resources>
-            <FlowDocument>
-                <Paragraph>
-                    <Run>LOL</Run>
-                </Paragraph>
-            </FlowDocument>
-        </RichTextBox>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="1*" />
+            <RowDefinition Height="18px" />
+        </Grid.RowDefinitions>
+        
+        <TextBox x:Name="BodyPreviewTxt" IsReadOnly="True" Background="#1E1E1E" BorderThickness="0" Padding="4px" FontFamily="Fira Code,Consolas,Courier New,monospace" FontSize="12" Foreground="#C9D1CE" />
+
+        <TextBlock Grid.Row="1">
+            <Run FontWeight="Bold">Request time:</Run>
+            <Run x:Name="CurRequestTime" FontFamily="Fira Code,Consolas,Courier New,monospace">-</Run>
+        </TextBlock>
     </Grid>
 </Window>

--- a/Project-Aurora/Project-Aurora/Settings/Window_GSIHttpDebug.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Window_GSIHttpDebug.xaml
@@ -1,0 +1,27 @@
+﻿<Window x:Class="Aurora.Settings.Window_GSIHttpDebug"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Aurora.Settings"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800"
+             Title="Aurora Game State Integration HTTP Request Viewer"
+             Loaded="Window_Loaded" Closing="Window_Closing">
+    <Grid>
+        <RichTextBox x:Name="BodyPreviewTxt" IsReadOnly="True" Background="#1E1E1E" BorderThickness="0" Padding="4px">
+            <RichTextBox.Resources>
+                <Style TargetType="{x:Type FlowDocument}">
+                    <Setter Property="FontFamily" Value="Fira Code,Consolas,Courier New,monospace" />
+                    <Setter Property="FontSize" Value="12" />
+                    <Setter Property="Foreground" Value="#C9D1CE" />
+                </Style>
+            </RichTextBox.Resources>
+            <FlowDocument>
+                <Paragraph>
+                    <Run>LOL</Run>
+                </Paragraph>
+            </FlowDocument>
+        </RichTextBox>
+    </Grid>
+</Window>

--- a/Project-Aurora/Project-Aurora/Settings/Window_GSIHttpDebug.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Window_GSIHttpDebug.xaml.cs
@@ -11,7 +11,6 @@ namespace Aurora.Settings {
     public partial class Window_GSIHttpDebug : Window {
 
         private Timer timeDisplayTimer;
-        private DateTime? previousRequestTime = null;
         private DateTime? lastRequestTime = null;
 
         public Window_GSIHttpDebug() {

--- a/Project-Aurora/Project-Aurora/Settings/Window_GSIHttpDebug.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Window_GSIHttpDebug.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json.Linq;
 using System;
+using System.Threading;
 using System.Windows;
 using System.Windows.Documents;
 
@@ -8,6 +9,10 @@ namespace Aurora.Settings {
     /// A window that logs the latest new game state recieved via HTTP, regardless of the provider.
     /// </summary>
     public partial class Window_GSIHttpDebug : Window {
+
+        private Timer timeDisplayTimer;
+        private DateTime? previousRequestTime = null;
+        private DateTime? lastRequestTime = null;
 
         public Window_GSIHttpDebug() {
             InitializeComponent();
@@ -21,18 +26,29 @@ namespace Aurora.Settings {
             // If a gamestate is already stored by the network listener, display it to the user immediately.
             if (Global.net_listener.CurrentGameState != null)
                 SetJsonText(Global.net_listener.CurrentGameState.json);
+
+            // Start a timer to update the time displays for the request
+            timeDisplayTimer = new Timer(_ => Dispatcher.Invoke(() => {
+                if (lastRequestTime.HasValue)
+                    CurRequestTime.Text = lastRequestTime.ToString() + " (" + (DateTime.Now - lastRequestTime).Value.TotalSeconds.ToString("0.00") + "s ago)";
+            }), null, 0, 50);
         }
 
         private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e) {
             // When the window closes, we need to clean up our listener, otherwise it'll keep listening and
             // this window will never get garbage collected.
             Global.net_listener.NewGameState -= Net_listener_NewGameState;
+
+            // Destory the timer to ensure it doesn't keep running and eating memory.
+            timeDisplayTimer.Dispose();
         }
 
         private void Net_listener_NewGameState(Profiles.IGameState gamestate) {
             // This needs to be invoked due to the UI thread being different from the networking thread.
             // Without this, an exception is thrown trying to update the text box.
             Dispatcher.Invoke(() => SetJsonText(gamestate.json));
+            // Also record the time this request came in
+            lastRequestTime = DateTime.Now;
         }
 
         /// <summary>
@@ -40,9 +56,7 @@ namespace Aurora.Settings {
         /// </summary>
         private void SetJsonText(string json) {
             // Pretty-print the JSON (add new lines and indentations)
-            string prettyJson = JToken.Parse(json).ToString(Newtonsoft.Json.Formatting.Indented);
-            BodyPreviewTxt.Document.Blocks.Clear();
-            BodyPreviewTxt.Document.Blocks.Add(new Paragraph(new Run(prettyJson)));
+            BodyPreviewTxt.Text = JToken.Parse(json).ToString(Newtonsoft.Json.Formatting.Indented);
         }
     }
 }

--- a/Project-Aurora/Project-Aurora/Settings/Window_GSIHttpDebug.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Window_GSIHttpDebug.xaml.cs
@@ -1,0 +1,48 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Windows;
+using System.Windows.Documents;
+
+namespace Aurora.Settings {
+    /// <summary>
+    /// A window that logs the latest new game state recieved via HTTP, regardless of the provider.
+    /// </summary>
+    public partial class Window_GSIHttpDebug : Window {
+
+        public Window_GSIHttpDebug() {
+            InitializeComponent();
+        }
+
+        private void Window_Loaded(object sender, RoutedEventArgs e) {
+            // When the window has opened and loaded, start listening to the NetworkListener for when it
+            // recieves new GameStates.
+            Global.net_listener.NewGameState += Net_listener_NewGameState;
+
+            // If a gamestate is already stored by the network listener, display it to the user immediately.
+            if (Global.net_listener.CurrentGameState != null)
+                SetJsonText(Global.net_listener.CurrentGameState.json);
+        }
+
+        private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e) {
+            // When the window closes, we need to clean up our listener, otherwise it'll keep listening and
+            // this window will never get garbage collected.
+            Global.net_listener.NewGameState -= Net_listener_NewGameState;
+        }
+
+        private void Net_listener_NewGameState(Profiles.IGameState gamestate) {
+            // This needs to be invoked due to the UI thread being different from the networking thread.
+            // Without this, an exception is thrown trying to update the text box.
+            Dispatcher.Invoke(() => SetJsonText(gamestate.json));
+        }
+
+        /// <summary>
+        /// Sets the text of the body preview text box to the given (json) string.
+        /// </summary>
+        private void SetJsonText(string json) {
+            // Pretty-print the JSON (add new lines and indentations)
+            string prettyJson = JToken.Parse(json).ToString(Newtonsoft.Json.Formatting.Indented);
+            BodyPreviewTxt.Document.Blocks.Clear();
+            BodyPreviewTxt.Document.Blocks.Add(new Paragraph(new Run(prettyJson)));
+        }
+    }
+}


### PR DESCRIPTION
Adds a button to _Settings_ > _Debug_ to open a window that shows the (formatted/indented) JSON that the network listener receives when waiting for GSI HTTP POST requests.

![image](https://user-images.githubusercontent.com/3984322/51080087-56178700-16cd-11e9-92f8-f97c4a89799f.png)

Useful for debug purposes when developing GSI mods.