### PR TITLE
Minor Animation Layer Bugfix

### DIFF
--- a/Project-Aurora/Project-Aurora/ConfigUI.xaml
+++ b/Project-Aurora/Project-Aurora/ConfigUI.xaml
@@ -7,7 +7,7 @@
              xmlns:local="clr-namespace:Aurora"
              xmlns:tb="http://www.hardcodet.net/taskbar"
              xmlns:Controls="clr-namespace:Aurora.Controls" xmlns:Settings="clr-namespace:Aurora.Settings" x:Class="Aurora.ConfigUI"
-             mc:Ignorable="d" Height="600" Width="1000" Title="Aurora" Loaded="Window_Loaded" Initialized="Window_Initialized" Closing="Window_Closing" Activated="Window_Activated" Deactivated="Window_Deactivated" HorizontalContentAlignment="Stretch" MinWidth="926" MinHeight="575" 
+             mc:Ignorable="d" Height="656" Width="1000" Title="Aurora" Loaded="Window_Loaded" Initialized="Window_Initialized" Closing="Window_Closing" Activated="Window_Activated" Deactivated="Window_Deactivated" HorizontalContentAlignment="Stretch" MinWidth="926" MinHeight="575" 
              DataContext="{Binding RelativeSource={RelativeSource Self}}" SizeChanged="Window_SizeChanged">
     <DockPanel x:Name="bg_grid" Background="#FF660000">
         <tb:TaskbarIcon x:Name="trayicon"

--- a/Project-Aurora/Project-Aurora/Settings/Layers/AnimationLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/AnimationLayerHandler.cs
@@ -265,7 +265,8 @@ namespace Aurora.Settings.Layers
 
             // If a new animation has been started or an existing one restarted, and we are translating based on key press
             // assign the target ket to the animation to allow it to calculate the offset.
-            anim.assignedKey = targetKey;
+            if (anim != null)
+                anim.assignedKey = targetKey;
         }
 
         public override void SetApplication(Application profile) {

--- a/Project-Aurora/Project-Aurora/Settings/Layers/AnimationLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/AnimationLayerHandler.cs
@@ -141,7 +141,7 @@ namespace Aurora.Settings.Layers
 
                 // Default values for the destination rect (the area that the canvas is drawn to) and animation offset
                 Rectangle destRect = new Rectangle(0, 0, Effects.canvas_width, Effects.canvas_height);
-                PointF offset = anim.offset;
+                PointF offset = Properties.KeyTriggerTranslate ? anim.offset : PointF.Empty;
 
                 // When ScaleToKeySequenceBounds is true, additional calculations are needed on the destRect and offset:
                 if (Properties.ScaleToKeySequenceBounds) {
@@ -265,8 +265,7 @@ namespace Aurora.Settings.Layers
 
             // If a new animation has been started or an existing one restarted, and we are translating based on key press
             // assign the target ket to the animation to allow it to calculate the offset.
-            if (Properties.KeyTriggerTranslate && anim != null)
-                anim.assignedKey = targetKey;
+            anim.assignedKey = targetKey;
         }
 
         public override void SetApplication(Application profile) {


### PR DESCRIPTION
* Changes logic so that the key is always recorded during the key press events (previously would only record when translating was set to true).
    * This fixes issue where holding a key during the "While key held" setting, with translating off would cause the animation to immediately restart.
    * Also fixes issue where "Terminate animation immediately" would not work if translating was off.
* Increases the size of the default unmaximised Aurora window to show all of the animation layer properties without needing to be resized.