### PR TITLE
"Fixed file name collisions that can cause profile data to be overritten." by @Wibble199

### DIFF
--- a/Project-Aurora/Project-Aurora/Profiles/Application.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/Application.cs
@@ -160,7 +160,7 @@ namespace Aurora.Profiles
         {
             ApplicationProfile profile = (ApplicationProfile)Activator.CreateInstance(Config.ProfileType);
             profile.ProfileName = profileName;
-            profile.ProfileFilepath = Path.Combine(GetProfileFolderPath(), GetValidFilename(profile.ProfileName) + ".json");
+            profile.ProfileFilepath = Path.Combine(GetProfileFolderPath(), GetUnusedFilename(GetProfileFolderPath(), profile.ProfileName) + ".json");
             return profile;
         }
 
@@ -169,7 +169,7 @@ namespace Aurora.Profiles
             if (Disposed)
                 return;
 
-            profile.ProfileFilepath = Path.Combine(GetProfileFolderPath(), GetValidFilename(profile.ProfileName) + ".json");
+            profile.ProfileFilepath = Path.Combine(GetProfileFolderPath(), GetUnusedFilename(GetProfileFolderPath(), profile.ProfileName) + ".json");
             this.Profiles.Add(profile);
         }
 
@@ -255,6 +255,14 @@ namespace Aurora.Profiles
                 filename = filename.Replace(c, '_');
 
             return filename;
+        }
+
+        protected string GetUnusedFilename(string dir, string filename) {
+            var safeName = GetValidFilename(filename);
+            if (!File.Exists(Path.Combine(dir, safeName + ".json"))) return safeName;
+            var i = 0;
+            while (File.Exists(Path.Combine(dir, safeName + "-" + ++i + ".json")));
+            return safeName + "-" + i;
         }
 
         public virtual string GetProfileFolderPath()

--- a/Project-Aurora/Project-Aurora/Profiles/Generic_Application/GenericApplication.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/Generic_Application/GenericApplication.cs
@@ -54,7 +54,7 @@ namespace Aurora.Profiles.Generic_Application
         {
             ApplicationProfile profile = (ApplicationProfile)Activator.CreateInstance(Config.ProfileType);
             profile.ProfileName = profileName;
-            profile.ProfileFilepath = Path.Combine(GetProfileFolderPath(), GetValidFilename(profile.ProfileName) + ".json");
+            profile.ProfileFilepath = Path.Combine(GetProfileFolderPath(), GetUnusedFilename(GetProfileFolderPath(), profile.ProfileName) + ".json");
             return profile;
         }
     }


### PR DESCRIPTION
"This minor change fixes errors when creating/importing profiles with the same name as existing ones. File name collisions can cause profile data to be overritten and also caused the weird behaviour that sometimes occured with the profile selection list not being able to select items.

Fixed by replacing GetValidFilename with a new method GetUnusedFilename in some places, which will find the next available file name based on the given profile name. E.G for a profile "test" it will find the first free file from: "test.json", "test-1.json", "test-2.json" etc.

Thanks to gitmacer for the bug testing and finding it was due to file names."