### PR TITLE
Add startup delay to Aurora settings

### DIFF
--- a/Project-Aurora/Project-Aurora/Settings/Control_Settings.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Control_Settings.xaml
@@ -128,7 +128,7 @@
                 <Grid>
                     <CheckBox x:Name="volume_as_brightness_enabled" Content="Use ALT + volume controls for global brightness (only when Aurora is out of focus)" HorizontalAlignment="Left" Margin="11,91,0,0" VerticalAlignment="Top" Checked="volume_as_brightness_enabled_Checked" Unchecked="volume_as_brightness_enabled_Checked"/>
                     <CheckBox x:Name="timed_dimming_checkbox" Content="Enable timed blackout of the keyboard" HorizontalAlignment="Left" Margin="10,184,0,0" VerticalAlignment="Top" Checked="timed_dimming_checkbox_Checked" Unchecked="timed_dimming_checkbox_Checked"/>
-                    <CheckBox x:Name="chkOverlayPreview" Content="Show Overlays and Underlays in Application Preview" HorizontalAlignment="Left" Margin="12,57,0,0" VerticalAlignment="Top" Checked="chkOverlayPreview_Checked" Unchecked="chkOverlayPreview_Checked"/>
+                    <CheckBox x:Name="chkOverlayPreview" Content="Show Overlays and Underlays in Application Preview" HorizontalAlignment="Left" Margin="12,62,0,0" VerticalAlignment="Top" Checked="chkOverlayPreview_Checked" Unchecked="chkOverlayPreview_Checked"/>
                     <TextBlock HorizontalAlignment="Left" Margin="11,230,0,0" TextWrapping="Wrap" Text="Blackout start time:" VerticalAlignment="Top"/>
                     <TextBlock HorizontalAlignment="Left" Margin="12,254,0,0" TextWrapping="Wrap" Text="Blackout end time:" VerticalAlignment="Top"/>
                     <CheckBox x:Name="timed_dimming_with_games_checkbox" Content="Apply timed blackout to game events" HorizontalAlignment="Left" Margin="10,205,0,0" VerticalAlignment="Top" Checked="timed_dimming_with_games_checkbox_Checked" Unchecked="timed_dimming_with_games_checkbox_Checked"/>
@@ -158,15 +158,18 @@
                     <xctk:IntegerUpDown x:Name="nighttime_end_minute_updown" HorizontalAlignment="Left" Height="24" Margin="389,249,0,0" VerticalAlignment="Top" Width="49" Value="1" Maximum="60" Minimum="0" MouseWheelActiveOnFocus="True" ValueChanged="nighttime_end_minute_updown_ValueChanged"/>
                     <TextBlock HorizontalAlignment="Left" Margin="381,252,0,0" TextWrapping="Wrap" Text=":" VerticalAlignment="Top" Width="3"/>
                     <CheckBox x:Name="nighttime_enabled_checkbox" Content="Enable nighttime color zones for&#x0a;General Application lighting profiles" HorizontalAlignment="Left" Margin="242,184,0,0" VerticalAlignment="Top" Unchecked="nighttime_enabled_checkbox_Checked" Checked="nighttime_enabled_checkbox_Checked"/>
-                    <TextBlock HorizontalAlignment="Left" Margin="178,33,0,0" TextWrapping="Wrap" Text="Closing mode:" VerticalAlignment="Top"/>
-                    <ComboBox x:Name="app_exit_mode" HorizontalAlignment="Left" Margin="261,30,0,0" VerticalAlignment="Top" Width="130" ItemsSource="{Binding Source={StaticResource appexitmode}}" ItemTemplate="{Binding Source={StaticResource appexitmodeTemplate}}" SelectionChanged="app_exit_mode_SelectionChanged"/>
-                    <CheckBox x:Name="start_silently_enabled" Content="Start Aurora minimized" HorizontalAlignment="Left" Margin="12,34,0,0" VerticalAlignment="Top" Unchecked="start_silently_enabled_Checked" Checked="start_silently_enabled_Checked"/>
+                    <TextBlock HorizontalAlignment="Left" Margin="178,38,0,0" TextWrapping="Wrap" Text="Closing mode:" VerticalAlignment="Top"/>
+                    <ComboBox x:Name="app_exit_mode" HorizontalAlignment="Left" Margin="261,35,0,0" VerticalAlignment="Top" Width="147" ItemsSource="{Binding Source={StaticResource appexitmode}}" ItemTemplate="{Binding Source={StaticResource appexitmodeTemplate}}" SelectionChanged="app_exit_mode_SelectionChanged"/>
+                    <CheckBox x:Name="start_silently_enabled" Content="Start Aurora minimized" HorizontalAlignment="Left" Margin="12,39,0,0" VerticalAlignment="Top" Unchecked="start_silently_enabled_Checked" Checked="start_silently_enabled_Checked"/>
                     <TextBlock HorizontalAlignment="Left" Margin="512,12,0,0" TextWrapping="Wrap" Text="Application Detection Method:" VerticalAlignment="Top"/>
                     <ComboBox x:Name="app_detection_mode" HorizontalAlignment="Left" Margin="677,10,0,0" VerticalAlignment="Top" Width="157" ItemsSource="{Binding Source={StaticResource AppDetectionMode}}" ItemTemplate="{Binding Source={StaticResource AppDetectionModeTemplate}}" SelectionChanged="app_detection_mode_SelectionChanged"/>
                     <TextBlock HorizontalAlignment="Left" Margin="12,111,0,0" TextWrapping="Wrap" Text="Global brightness modifier: " VerticalAlignment="Top"/>
                     <TextBlock x:Name="lblGlobalBrightness" HorizontalAlignment="Left" Margin="335,111,0,0" TextWrapping="Wrap" Text="0 %" VerticalAlignment="Top"/>
                     <Slider x:Name="sldGlobalBrightness" HorizontalAlignment="Left" Margin="180,111,0,0" VerticalAlignment="Top" Width="150" Maximum="1" ValueChanged="sliderPercentages_ValueChanged" Value="{Binding GlobalBrightness, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Tag="{Binding ElementName=lblGlobalBrightness, Path=.}"/>
-                    <CheckBox x:Name="chkHigherPriority" Content="Run Aurora at High priority" HorizontalAlignment="Left" Margin="178,10,0,0" VerticalAlignment="Top" IsChecked="{Binding HighPriority, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Checked="chkHigherPriority_IsCheckedChanged" Unchecked="chkHigherPriority_IsCheckedChanged"/>
+                    <CheckBox x:Name="chkHigherPriority" Content="High priority" HorizontalAlignment="Left" Margin="158,10,0,0" VerticalAlignment="Top" IsChecked="{Binding HighPriority, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Checked="chkHigherPriority_IsCheckedChanged" Unchecked="chkHigherPriority_IsCheckedChanged"/>
+                    <TextBlock Text="Delay:" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="278,10,0,0" />
+                    <xctk:IntegerUpDown x:Name="startDelayAmount" Height="22" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="315,8,0,0" Width="69" Increment="15" ValueChanged="startDelayAmount_ValueChanged" />
+                    <TextBlock Text="sec" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="389,10,0,0" />
                 </Grid>
             </TabItem>
             <TabItem Header="Volume Overlay">

--- a/Project-Aurora/Project-Aurora/Settings/Control_Settings.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Control_Settings.xaml.cs
@@ -51,6 +51,7 @@ namespace Aurora.Settings
                         definition.Actions.Add(new ExecAction(exePath, "-silent", Path.GetDirectoryName(exePath)));
                         service.RootFolder.RegisterTaskDefinition(StartupTaskID, definition);
                         this.run_at_win_startup.IsChecked = task.Enabled;
+                        startDelayAmount.Value = task.Definition.Triggers.FirstOrDefault(t => t.TriggerType == TaskTriggerType.Logon) is LogonTrigger trigger ? (int)trigger.Delay.TotalSeconds : 0;
                     }
                     else
                     {
@@ -1059,5 +1060,15 @@ namespace Aurora.Settings
         }
 
         private void btnShowGSILog_Click(object sender, RoutedEventArgs e) => new Window_GSIHttpDebug().Show();
+
+        private void startDelayAmount_ValueChanged(object sender, RoutedPropertyChangedEventArgs<object> e) {
+            using (TaskService service = new TaskService()) {
+                var task = service.FindTask(StartupTaskID);
+                if (task != null && task.Definition.Triggers.FirstOrDefault(t => t.TriggerType == TaskTriggerType.Logon) is LogonTrigger trigger) {
+                    trigger.Delay = new TimeSpan(0, 0, ((IntegerUpDown)sender).Value ?? 0);
+                    task.RegisterChanges();
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
This minor change adds a numeric stepper allowing the user to set the delay of the Aurora startup task, without needing to go to the Task Scheduler. Delaying Aurora's startup fixes a relatively common issue some users have where Aurora starts before the vendor software and doesn't initalise the devices automatically.

![image](https://user-images.githubusercontent.com/3984322/52633927-c75d7c00-2ebd-11e9-90d7-58f9f8dc858c.png)
