### PR TITLE
Add option to toggle buffer with Interactive Layer

### DIFF
--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_InteractiveLayer.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_InteractiveLayer.xaml
@@ -40,5 +40,6 @@
         <TextBlock x:Name="interactive_effects_width_label" HorizontalAlignment="Left" Margin="225,146,0,0" TextWrapping="Wrap" Text="1 px" VerticalAlignment="Top"/>
         <CheckBox x:Name="interactive_effects_start_on_key_up_enabled" Content="Start progress when key released" HorizontalAlignment="Left" Margin="0,167,0,0" VerticalAlignment="Top" Checked="interactive_effects_start_on_key_up_enabled_Checked" Unchecked="interactive_effects_start_on_key_up_enabled_Checked"/>
         <Controls:KeySequence x:Name="KeySequence_keys" Margin="354,0,0,0" RecordingTag="Interactive Layer (Excluded Keys)" Title="Excluded Keys" SequenceUpdated="KeySequence_keys_SequenceUpdated" HorizontalAlignment="Left" Width="230"/>
+        <CheckBox x:Name="usePressBuffer" Content="Mitigate rapid key presses" HorizontalAlignment="Left" Margin="0,188,0,0" VerticalAlignment="Top" Checked="usePressBuffer_Checked" Unchecked="usePressBuffer_Checked"/>
     </Grid>
 </UserControl>

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_InteractiveLayer.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_InteractiveLayer.xaml.cs
@@ -52,6 +52,7 @@ namespace Aurora.Settings.Layers
                 this.interactive_effects_width_label.Text = (this.DataContext as InteractiveLayerHandler).Properties._EffectWidth + " px";
                 this.interactive_effects_width_slider.Value = (float)(this.DataContext as InteractiveLayerHandler).Properties._EffectWidth;
                 this.interactive_effects_start_on_key_up_enabled.IsChecked = (this.DataContext as InteractiveLayerHandler).Properties._WaitOnKeyUp;
+                this.usePressBuffer.IsChecked = (this.DataContext as InteractiveLayerHandler).Properties._UsePressBuffer ?? true;
                 this.KeySequence_keys.Sequence = (this.DataContext as InteractiveLayerHandler).Properties._Sequence;
                 this.KeySequence_keys.FreestyleEnabled = false;
 
@@ -151,6 +152,11 @@ namespace Aurora.Settings.Layers
             {
                 (this.DataContext as InteractiveLayerHandler).Properties._WaitOnKeyUp = (sender as CheckBox).IsChecked.Value;
             }
+        }
+
+        private void usePressBuffer_Checked(object sender, RoutedEventArgs e) {
+            if (IsLoaded && settingsset && this.DataContext is InteractiveLayerHandler && sender is CheckBox && (sender as CheckBox).IsChecked.HasValue)
+                (this.DataContext as InteractiveLayerHandler).Properties._UsePressBuffer = (sender as CheckBox).IsChecked.Value;
         }
     }
 }

--- a/Project-Aurora/Project-Aurora/Settings/Layers/InteractiveLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/InteractiveLayerHandler.cs
@@ -85,6 +85,10 @@ namespace Aurora.Settings.Layers
 
         [JsonIgnore]
         public int EffectWidth { get { return Logic._EffectWidth ?? _EffectWidth ?? 0; } }
+        
+        public bool? _UsePressBuffer { get; set; }
+        [JsonIgnore]
+        public bool UsePressBuffer => Logic._UsePressBuffer ?? _UsePressBuffer ?? true;
 
         public InteractiveLayerHandlerProperties() : base() { }
 
@@ -168,7 +172,7 @@ namespace Aurora.Settings.Layers
             {
                 if (TimeOfLastPress.ContainsKey(device_key))
                 {
-                    if ((currentTime = Utils.Time.GetMillisecondsSinceEpoch()) - TimeOfLastPress[device_key] < pressBuffer)
+                    if (Properties.UsePressBuffer && (currentTime = Utils.Time.GetMillisecondsSinceEpoch()) - TimeOfLastPress[device_key] < pressBuffer)
                         return;
                     else
                         TimeOfLastPress.Remove(device_key);
@@ -290,7 +294,7 @@ namespace Aurora.Settings.Layers
             {
                 foreach (var lengthPresses in TimeOfLastPress.ToList())
                 {
-                    if (currenttime - lengthPresses.Value > pressBuffer)
+                    if (!Properties.UsePressBuffer || currenttime - lengthPresses.Value > pressBuffer)
                     {
                         TimeOfLastPress.Remove(lengthPresses.Key);
                     }


### PR DESCRIPTION
The interactive layer has a `pressBuffer` constant set to `300`. This is the minimum time between the effects for the same key. For example, if a key is pressed it will animate. If pressed again 200ms later, it will not. If pressed again 200ms later, it will etc.

This PR adds a checkbox option to the interactive layer to disable this functionality, allowing rapid keypresses to keep triggering an effect. By default, this option is enabled, so as to behave as it used to.

Resolves #1448 