### PR TITLE
Fixed RL Background Layer options being overriden on load

### DIFF
--- a/Project-Aurora/Project-Aurora/Profiles/RocketLeague/Layers/Control_RocketLeagueBackgroundLayer.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/RocketLeague/Layers/Control_RocketLeagueBackgroundLayer.xaml.cs
@@ -45,7 +45,7 @@ namespace Aurora.Profiles.RocketLeague.Layers
                 this.ColorPicker_Default.SelectedColor = Utils.ColorUtils.DrawingColorToMediaColor((this.DataContext as RocketLeagueBackgroundLayerHandler).Properties._DefaultColor ?? System.Drawing.Color.Empty);
                 this.Checkbox_ShowTeamScoreSplit.IsChecked = (this.DataContext as RocketLeagueBackgroundLayerHandler).Properties._ShowTeamScoreSplit ?? false;
                 this.Checkbox_ShowGoalExplosion.IsChecked = ( this.DataContext as RocketLeagueBackgroundLayerHandler ).Properties._ShowGoalExplosion ?? false;
-                this.Checkbox_ShowEnemyExplosion.IsChecked = (this.DataContext as RocketLeagueBackgroundLayerHandler).Properties._ShowGoalExplosion ?? false;
+                this.Checkbox_ShowEnemyExplosion.IsChecked = (this.DataContext as RocketLeagueBackgroundLayerHandler).Properties._ShowEnemyExplosion ?? false;
 
                 settingsset = true;
             }


### PR DESCRIPTION
**List any issues that this PR fixes:**
- The Rocket League Background Layer was incorrectly loading the wrong saved property on ShowEnemyExplosion, using the value of ShowGoalExplosion, overriding it on every load.