### PR TITLE
Add NodeMCU ESP8266 microcontroller support for driving external LED strips

### DIFF
--- a/AuroraArduino/AuroraArduino.ino
+++ b/AuroraArduino/AuroraArduino.ino
@@ -1,0 +1,162 @@
+
+#include <ESP8266WiFi.h>
+#include <ESP8266WebServer.h>
+#include <ArduinoJson.h>
+#define FASTLED_ESP8266_RAW_PIN_ORDER
+
+#include "FastLED.h"
+
+#if FASTLED_VERSION < 3001000
+#error "Requires FastLED 3.1 or later"
+#endif
+
+// !!!!!!!!!! SETTINGS !!!!!!!!!!
+#define LED_PIN D2				// Digital pin connected to the LED strip
+#define NUM_LEDS 150			// Number of LEDs connected to your device
+#define MAX_LED_BRIGHTNESS 128	// Maximum brightness of the LEDs (0-255)
+#define USED_PORT 8032			// Port to be used
+
+//!!!!!!!!!!! IP SETTIGNS !!!!!!!!!!
+#define USE_STATIC_IP 1		// If you don't want to use a static IP, comment out this line
+
+// Set static IP parameters
+IPAddress ip(192, 168, 2, 6);
+IPAddress gateway(192, 168, 2, 1);
+IPAddress subnet(255, 255, 255, 0);
+IPAddress dns(192, 168, 2, 1);
+
+//Default settings for WS2812B LED-Strip
+#define COLOR_ORDER GRB
+#define LED_TYPE WS2812B
+#define UPDATES_PER_SECOND 1000
+
+#define PI_URL_SUFFIX_START "/start"
+#define PI_URL_SUFFIX_STOP "/stop"
+#define PI_URL_SUFFIX_QUIT "/quit"
+#define PI_URL_SUFFIX_SETLIGHTS "/lights"
+
+// WiFi Parameters
+const char* ssid = "XXXXXXXXXXXSSIDXXXXXXXXXXXXXXX";
+const char* password = "XXXXXXXPASSWDXXXXXXXX";
+
+//Define a webserver on defined port
+ESP8266WebServer server(USED_PORT);
+//Declare pointer to JSON  memory buffer
+DynamicJsonBuffer * jsonBuffer;
+//Define a struct of LED color values
+struct CRGB leds[NUM_LEDS];
+
+bool isStarted = false;
+
+void setup()
+{
+	//Initialize serial console
+	Serial.begin(115200);
+#if USE_STATIC_IP == 1
+	Serial.println("Using static IP");
+	WiFi.config(ip, dns, gateway, subnet);
+#endif // 
+
+	//Initialize wifi connection
+	//WiFi.mode(WIFI_STA);
+	WiFi.begin(ssid, password);
+	while (WiFi.waitForConnectResult() != WL_CONNECTED) {
+		Serial.println("Connection Failed! Rebooting...");
+		delay(5000);
+		ESP.restart();
+	}
+
+	Serial.println("Ready");
+	Serial.print("IP address: ");
+	Serial.println(WiFi.localIP());
+
+	//Define REST callback methods
+	server.on(PI_URL_SUFFIX_START, HTTP_POST, OnStart);
+	server.on(PI_URL_SUFFIX_STOP,  HTTP_POST, OnStop);
+	server.on(PI_URL_SUFFIX_QUIT,  HTTP_POST, OnQuit);
+	server.on(PI_URL_SUFFIX_SETLIGHTS, HTTP_POST, OnSetLights);
+
+	//Start webserver
+	server.begin();
+
+	//Initializing LEDs
+	Serial.println("Initializing LEDs");
+	FastLED.addLeds<LED_TYPE, LED_PIN, COLOR_ORDER>(leds, NUM_LEDS).setCorrection(TypicalLEDStrip);
+	Serial.print("Setting brightness to: ");
+	Serial.println(MAX_LED_BRIGHTNESS);
+	FastLED.setBrightness(MAX_LED_BRIGHTNESS);
+
+	//Calculate the necessary size for the json object in memeory
+	const size_t capacity = JSON_ARRAY_SIZE(NUM_LEDS) + JSON_OBJECT_SIZE(1) + 1010;
+	//Allocate memory on heap for json objects
+	jsonBuffer = new DynamicJsonBuffer(capacity);
+
+}
+void OnStart()
+{
+	Serial.println("Starting");
+	server.send(200, "text/plain", "Starting");
+	isStarted = true;
+}
+void OnStop()
+{
+	Serial.println("Stopping");
+	server.send(200, "text/plain", "Stopping");
+
+	isStarted = false;
+}
+void OnQuit()
+{
+	Serial.println("Quitting");
+	server.send(200, "text/plain", "Quitting");
+
+	isStarted = false;
+}
+void OnSetLights()
+{
+	if (server.hasArg("plain") == false)
+	{
+		server.send(200, "text/plain", "Body not received");
+		return;
+	}
+	server.send(200, "text/plain", "Body received");
+	String message = server.arg("plain");
+	
+	JsonObject& root = jsonBuffer->parseObject(message);
+	
+	if (!root.success())
+	{
+		Serial.println("Parsing failed");
+		return;
+	}
+	//Serial.println("Parsing succeeded");
+	JsonArray& col = root["col"];
+	//Serial.print("Number of elements : ");
+	for (uint32_t i = 0; i < NUM_LEDS; ++i)
+	{
+		uint8_t r = (uint32_t)col[i] >> 16 & 0xFF;
+		uint8_t g = (uint32_t)col[i] >> 8 & 0xFF;
+		uint8_t b = (uint32_t)col[i] & 0xFF;
+
+		leds[i].r = r;
+		leds[i].g = g;
+		leds[i].b = b;
+	}
+	jsonBuffer->clear();
+	
+}
+
+void loop()
+{
+	server.handleClient();
+	if (isStarted)
+	{
+		FastLED.show();
+	}
+	else
+	{
+		FastLED.clear();
+	}
+	FastLED.delay(1000 / UPDATES_PER_SECOND);
+
+}

--- a/README.md
+++ b/README.md
@@ -150,3 +150,6 @@ This fork includes a script for Raspberry PI and Aurora to transmit lighting inf
 * [rpi_ws281x](https://github.com/jgarff/rpi_ws281x) - Used for NeoPixel LED lighting
 * [LedStrip](https://github.com/glnds/LedStrip) - Used for LED lighting
 * [Gson](https://github.com/google/gson) - Used for Json parsing
+* [FastLED](https://github.com/FastLED/FastLED) - Used for LED lighting on ESP8266
+* [ArduinoJson](https://github.com/bblanchon/ArduinoJson) - Used for Json parsing on ESP8266
+* [Arduino](https://github.com/esp8266/Arduino) - Arduino core for ESP8266 WiFi chip

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Aurora Raspberry Pi LED Script
 
-This fork includes a script for Raspberry PI and Aurora to transmit lighting information to LED lights connected to the Raspberry PI.
+This fork includes a script for Raspberry PI and ESP8366 microcontroller as well as Aurora to transmit lighting information to LED lights connected to the Raspberry PI.
 
 # Requirements
 * [Aurora](https://github.com/antonpup/Aurora)
-* A Raspberry Pi
-* LED strips connected to the Raspberry Pi
-* Pi connected to your home network
+* A Raspberry Pi or a Nodemcu ESP8366 microcontroller
+* LED strips connected to the Raspberry Pi/ESP8366
+* Pi/ESP8266 connected to your home network
 * Fast local network connection
 
 ## Video demonstration
@@ -14,6 +14,7 @@ This fork includes a script for Raspberry PI and Aurora to transmit lighting inf
 [![](http://img.youtube.com/vi/p0WiaQwmSYQ/0.jpg)](https://www.youtube.com/watch?v=p0WiaQwmSYQ)
 
 # How to Install & Run on a NeoPixel LED Strip
+## Running the software on a Raspberry Pi
 1. Make sure your Raspberry Pi is configured to work with Python. Run the following commands:
     ```
 	
@@ -58,9 +59,29 @@ This fork includes a script for Raspberry PI and Aurora to transmit lighting inf
 	
     ```
 7. Run "sudo python aurora_neopixel_pi.py". Raspberry Pi portion is now complete.
+## Running the software on the ESP8266
 
-8. On your PC, copy file "Scripts/Devices/rpi_script.cs" to "*Aurora install location*/Scripts/Devices/rpi_script.cs"
-9. Open the "rpi_script.cs" file to configure the script. Adjust following lines:
+1. If you haven't worked with microcontrollers before, you should download and install the Arduino IDE first [here](https://www.arduino.cc/en/main/software)
+2. In order to communicate with the ESP8266 microcontroller an additional USB driver is necessary. You can find this driver [here](https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers)
+3. Open Arduino IDE -> File -> Preferences and add the following URL as an additional boards manager URL:
+``
+http://arduino.esp8266.com/stable/package_esp8266com_index.json
+``
+4. Go to Tools -> Boards -> Boards Manager search for "esp8266" and install the first result
+5. Go to Tools -> Boards and select "NodeMCU 0.9"
+6. Make sure that the right COM-Port is selected at Tools -> Port and the ESP8266 is connected to your PC
+7. Open the projects *.ino* file in the Arduino IDE
+8. Go to Sketch -> Include Library -> Manage Libraries and install
+	* ArduinoJson (Version 5.13.4)
+	* FastLED (Version 3.2.6)
+9. Replace the Wifi parameters  "SSID" and "Password"
+10. Notice that the data line of the LED-Strip is expected to be connected to the D2 pin
+11. Change the IP address, gateway, netmask and dns according to your own network
+12. Click upload
+
+# Configuration of the Aurora software on yor PC
+1. On your PC, copy file "Scripts/Devices/rpi_script.cs" to "*Aurora install location*/Scripts/Devices/rpi_script.cs"
+2. Open the "rpi_script.cs" file to configure the script. Adjust following lines:
     ``` C#
     
     //!!!!!!!!!! SCRIPT SETTINGS !!!!!!!!!!//
@@ -90,7 +111,7 @@ This fork includes a script for Raspberry PI and Aurora to transmit lighting inf
         };
         
     ```
-10. Run Aurora and lighting should now work.
+3. Run Aurora and lighting should now work.
 
 
 # How to Install & Run on a LPD8806 LED Strip


### PR DESCRIPTION
This PR introduces a microcontroller compatible implementation of the already implemented LED driver software for the Raspberry Pi.

It allows the user to use a microcontroller (in my case NodeMCUs ESP8266) to receive, deserialize and update the LED status instead of a Raspberry Pi, which is more expensive, bigger and consumes more power.
Since the ESP8266 is WiFi capable this can be done completely wireless.
This new approach is entirely backward compatible with the already existing interface to Aurora which is used to transmit the lighting updates to the Raspberry Pi.

**List any issues that this PR fixes:** fixes # , etc...
<!-- For example, "Fixes #287 , fixes #100 , and fixes #20" -->
Fixes https://github.com/antonpup/Aurora/issues/473
Fixes https://github.com/antonpup/Aurora/issues/996

**This pull request proposes the following changes:**
<!-- List changes that this RP includes -->
* Added a C based and ESP8266 compatible implementation of the already implemented Raspberry Pi software, which:
	* Starts a webserver with REST endpoints on the microcontroller
	* Receives and deserializes the Json lighting updates
	* Sends the new RGB values to the LED strips

- Updated README on how to compile and upload the code to the microcontroller
- Added three new libraries:
	* ArduinoJson (Json library for Arduino microcontrollers)
	* FastLED (LED driver interface which supports up to 14 different LED chipsets (more [here](https://github.com/FastLED/FastLED#supported-led-chipsets))
	* ESP8266 Arduino firmware