### PR TITLE
Minor Overrides System Improvements

### DIFF
--- a/Project-Aurora/Project-Aurora/Controls/Control_FieldPresenter.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Controls/Control_FieldPresenter.xaml.cs
@@ -85,15 +85,8 @@ namespace Aurora.Controls {
             { typeof(RealColor), bind => new ColorPicker{ ColorMode = ColorMode.ColorCanvas }.SetBindingChain(ColorPicker.SelectedColorProperty, bind, new RealColorConverter()) },
 
             // Gradient colour
-            { typeof(Settings.LayerEffectConfig), bind => {
-                // Still needs some work to become properly useful since the animation effect and speed and stuff are stored
-                // in the layer effect config in addition to the brush, so this causes those values to also get overridden.
-                var canvas = new ColorBox.ColorBox();
-                var src = (Control_FieldPresenter)bind.Source;
-                canvas.Brush = ((Settings.LayerEffectConfig)src.Value).brush.GetMediaBrush();
-                canvas.BrushChanged += (sender, e) => { ((Settings.LayerEffectConfig)src.Value).brush = new EffectsEngine.EffectBrush(e.Brush); };
-                return canvas;
-            } },
+            { typeof(Settings.LayerEffectConfig), bind => new Control_GradientEditor((Settings.LayerEffectConfig)((Control_FieldPresenter)bind.Source).Value) },
+            { typeof(EffectsEngine.EffectBrush), bind => new ColorBox.ColorBox().SetBindingChain(ColorBox.ColorBox.BrushProperty, bind, new EffectBrushToBrushConverter(), BindingMode.TwoWay) },
 
             // KeySequences
             { typeof(Settings.KeySequence), bind => new Controls.KeySequence {

--- a/Project-Aurora/Project-Aurora/Controls/Control_GradientEditor.xaml
+++ b/Project-Aurora/Project-Aurora/Controls/Control_GradientEditor.xaml
@@ -1,0 +1,45 @@
+﻿<UserControl x:Class="Aurora.Controls.Control_GradientEditor"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Aurora.Controls"
+             xmlns:ncore="http://schemas.ncore.com/wpf/xaml/colorbox"
+             xmlns:utils="clr-namespace:Aurora.Utils"
+             xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
+             mc:Ignorable="d" 
+             d:DesignHeight="160" d:DesignWidth="240">
+    <UserControl.Resources>
+        <utils:EffectBrushToBrushConverter x:Key="BrushConverter" />
+    </UserControl.Resources>
+    
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="100" />
+            <ColumnDefinition />
+        </Grid.ColumnDefinitions>
+
+
+        <Label Content="Brush:" Grid.Row="0" HorizontalAlignment="Right" />
+        <ncore:ColorBox Grid.Row="0" Grid.Column="1" Brush="{Binding Brush, Converter={StaticResource BrushConverter}, Mode=TwoWay}" />
+
+        <Label Content="Animation Type:" Grid.Row="1" HorizontalAlignment="Right" />
+        <ComboBox x:Name="animTypeCb" Grid.Row="1" Grid.Column="1" Margin="0,0,0,2" DisplayMemberPath="Key" SelectedValuePath="Value"  SelectedValue="{Binding AnimationType}" />
+
+        <Label Content="Speed:" Grid.Row="2" HorizontalAlignment="Right" />
+        <xctk:SingleUpDown Grid.Row="2" Grid.Column="1" Value="{Binding Speed}" Margin="0,2" />
+
+        <Label Content="Angle:" Grid.Row="3" HorizontalAlignment="Right" />
+        <xctk:SingleUpDown Grid.Row="3" Grid.Column="1" Value="{Binding Angle}" Margin="0,2" />
+        
+        <CheckBox Grid.Row="4" Grid.Column="1" Content="Reverse Direction?" IsChecked="{Binding AnimationReverse}" />
+    </Grid>
+</UserControl>

--- a/Project-Aurora/Project-Aurora/Controls/Control_GradientEditor.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Controls/Control_GradientEditor.xaml.cs
@@ -1,0 +1,18 @@
+﻿using Aurora.Settings;
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Windows.Controls;
+using System.Windows.Data;
+
+namespace Aurora.Controls {
+
+    public partial class Control_GradientEditor : UserControl {
+
+        public Control_GradientEditor(LayerEffectConfig gradient) {
+            InitializeComponent();
+            animTypeCb.ItemsSource = Utils.EnumUtils.GetEnumItemsSource<AnimationType>();
+            DataContext = gradient;
+        }
+    }
+}

--- a/Project-Aurora/Project-Aurora/Project-Aurora.csproj
+++ b/Project-Aurora/Project-Aurora/Project-Aurora.csproj
@@ -331,6 +331,9 @@
     <Compile Include="Controls\Control_FieldPresenter.xaml.cs">
       <DependentUpon>Control_FieldPresenter.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Controls\Control_GradientEditor.xaml.cs">
+      <DependentUpon>Control_GradientEditor.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Controls\Control_PluginManager.xaml.cs">
       <DependentUpon>Control_PluginManager.xaml</DependentUpon>
     </Compile>
@@ -1559,6 +1562,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Controls\Control_FieldPresenter.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Controls\Control_GradientEditor.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/Project-Aurora/Project-Aurora/Settings/Control_LayerControlPresenter.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Control_LayerControlPresenter.xaml.cs
@@ -61,8 +61,8 @@ namespace Aurora.Settings
             cmbLayerType.SelectedItem = Global.LightingStateManager.LayerHandlers[Layer.Handler.ID];
             ctrlLayerTypeConfig.Content = layer.Control;
             chkLayerSmoothing.IsChecked = Layer.Handler.EnableSmoothing;
-            chk_ExcludeMask.IsChecked = Layer.Handler.EnableExclusionMask;
-            keyseq_ExcludeMask.Sequence = Layer.Handler.ExclusionMask;
+            chk_ExcludeMask.IsChecked = Layer.Handler._EnableExclusionMask ?? false;
+            keyseq_ExcludeMask.Sequence = Layer.Handler._ExclusionMask;
             sldr_Opacity.Value = (int)(Layer.Handler._Opacity ?? 1f * 100.0f);
             lbl_Opacity_Text.Text = $"{(int)sldr_Opacity.Value} %";
 
@@ -95,8 +95,8 @@ namespace Aurora.Settings
 
                 ctrlLayerTypeConfig.Content = _Layer.Control;
                 chkLayerSmoothing.IsChecked = _Layer.Handler.EnableSmoothing;
-                chk_ExcludeMask.IsChecked = Layer.Handler.EnableExclusionMask;
-                keyseq_ExcludeMask.Sequence = Layer.Handler.ExclusionMask;
+                chk_ExcludeMask.IsChecked = Layer.Handler._EnableExclusionMask ?? false;
+                keyseq_ExcludeMask.Sequence = Layer.Handler._ExclusionMask;
                 sldr_Opacity.Value = (int)(Layer.Handler.Opacity * 100.0f);
                 lbl_Opacity_Text.Text = $"{(int)sldr_Opacity.Value} %";
                 this._Layer.AssociatedApplication.SaveProfiles();
@@ -136,7 +136,7 @@ namespace Aurora.Settings
         private void chk_ExcludeMask_Checked(object sender, RoutedEventArgs e)
         {
             if (IsLoaded && !isSettingNewLayer && sender is CheckBox)
-                Layer.Handler.EnableExclusionMask = (sender as CheckBox).IsChecked.Value;
+                Layer.Handler._EnableExclusionMask = (sender as CheckBox).IsChecked.Value;
 
             keyseq_ExcludeMask.IsEnabled = Layer.Handler.EnableExclusionMask;
         }
@@ -144,7 +144,7 @@ namespace Aurora.Settings
         private void keyseq_ExcludeMask_SequenceUpdated(object sender, EventArgs e)
         {
             if (IsLoaded && !isSettingNewLayer && sender is Aurora.Controls.KeySequence)
-                Layer.Handler.ExclusionMask = (sender as Aurora.Controls.KeySequence).Sequence;
+                Layer.Handler._ExclusionMask = (sender as Aurora.Controls.KeySequence).Sequence;
         }
 
         private void sldr_Opacity_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)

--- a/Project-Aurora/Project-Aurora/Settings/LayerEffectConfig.cs
+++ b/Project-Aurora/Project-Aurora/Settings/LayerEffectConfig.cs
@@ -27,6 +27,19 @@ namespace Aurora.Settings
         public bool animation_reverse;
         public EffectBrush brush;
 
+        // Added properties so we can use WPF to bind to the fields
+        // Unfortunately we CANNOT use auto-properties (and keep the correct naming convention (upper-case first letter)) because
+        // then there would be no lowercase name and the JSON would not be able to be deserialized properly, breaking all existing
+        // profiles. >:( Little bit frustrating and verbose. Perhaps we can replace this next time there is a breaking change...
+        [JsonIgnore] public Color Primary { get => primary; set => primary = value; }
+        [JsonIgnore] public Color Secondary { get => secondary; set => secondary = value; }
+        [JsonIgnore] public float Speed { get => speed; set => speed = value; }
+        [JsonIgnore] public float Angle { get => angle; set => angle = value; }
+        [JsonIgnore] public AnimationType AnimationType { get => animation_type; set => animation_type = value; }
+        [JsonIgnore] public bool AnimationReverse { get => animation_reverse; set => animation_reverse = value; }
+        [JsonIgnore] public EffectBrush Brush { get => brush; set => brush = value; }
+
+
         [JsonIgnoreAttribute]
         public float shift_amount = 0.0f;
         [JsonIgnoreAttribute]
@@ -63,34 +76,6 @@ namespace Aurora.Settings
                     }
                 }
                 );
-        }
-
-        public LayerEffectConfig SetAnimationSpeed(float speed)
-        {
-            this.speed = speed;
-
-            return this;
-        }
-
-        public LayerEffectConfig SetAnimationAngle(float angle)
-        {
-            this.angle = angle;
-
-            return this;
-        }
-
-        public LayerEffectConfig SetAnimationType(AnimationType type)
-        {
-            animation_type = type;
-
-            return this;
-        }
-
-        public LayerEffectConfig SetAnimationDirection(bool reverse)
-        {
-            animation_reverse = reverse;
-
-            return this;
         }
 
         public LayerEffectConfig(LayerEffectConfig otherConfig)

--- a/Project-Aurora/Project-Aurora/Settings/Layers/AmbilightLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/AmbilightLayerHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Aurora.EffectsEngine;
 using Aurora.Profiles;
+using Aurora.Settings.Overrides;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -37,7 +38,7 @@ namespace Aurora.Settings.Layers
         [Description("Specific Process")]
         SpecificProcess = 3
     }
-
+    
     public class AmbilightLayerHandlerProperties : LayerHandlerProperties2Color<AmbilightLayerHandlerProperties>
     {
         public AmbilightType? _AmbilightType { get; set; }
@@ -68,6 +69,8 @@ namespace Aurora.Settings.Layers
         }
     }
 
+    [LogicOverrideIgnoreProperty("_PrimaryColor")]
+    [LogicOverrideIgnoreProperty("_SecondaryColor")]
     public class AmbilightLayerHandler : LayerHandler<AmbilightLayerHandlerProperties>
     {
         private static float image_scale_x = 0;

--- a/Project-Aurora/Project-Aurora/Settings/Layers/AnimationLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/AnimationLayerHandler.cs
@@ -99,6 +99,7 @@ namespace Aurora.Settings.Layers
     }
 
     [LogicOverrideIgnoreProperty("_PrimaryColor")]
+    [LogicOverrideIgnoreProperty("_SecondaryColor")]
     public class AnimationLayerHandler : LayerHandler<AnimationLayerHandlerProperties> {
 
         private List<RunningAnimation> runningAnimations = new List<RunningAnimation>();

--- a/Project-Aurora/Project-Aurora/Settings/Layers/AnimationLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/AnimationLayerHandler.cs
@@ -2,6 +2,7 @@
 using Aurora.EffectsEngine;
 using Aurora.EffectsEngine.Animations;
 using Aurora.Profiles;
+using Aurora.Settings.Overrides;
 using Aurora.Settings.Overrides.Logic;
 using Aurora.Utils;
 using Newtonsoft.Json;
@@ -97,6 +98,7 @@ namespace Aurora.Settings.Layers
         }
     }
 
+    [LogicOverrideIgnoreProperty("_PrimaryColor")]
     public class AnimationLayerHandler : LayerHandler<AnimationLayerHandlerProperties> {
 
         private List<RunningAnimation> runningAnimations = new List<RunningAnimation>();

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_AnimationLayer.xaml.cs
@@ -45,7 +45,7 @@ namespace Aurora.Settings.Layers
             );
             triggerModeLCV.GroupDescriptions.Add(new PropertyGroupDescription("Description"));
             triggerModeCb.ItemsSource = triggerModeLCV;
-            stackModeCb.ItemsSource = Enum.GetValues(typeof(AnimationStackMode)).Cast<AnimationStackMode>().ToDictionary(mode => mode.GetDescription(), mode => mode);
+            stackModeCb.ItemsSource = EnumUtils.GetEnumItemsSource<AnimationStackMode>();
 
             UpdateUI();
         }

--- a/Project-Aurora/Project-Aurora/Settings/Layers/DefaultLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/DefaultLayerHandler.cs
@@ -6,9 +6,14 @@ using System.Threading.Tasks;
 using System.Windows.Controls;
 using Aurora.EffectsEngine;
 using Aurora.Profiles;
+using Aurora.Settings.Overrides;
 
 namespace Aurora.Settings.Layers
 {
+    [LogicOverrideIgnoreProperty("_PrimaryColor")]
+    [LogicOverrideIgnoreProperty("_Opacity")]
+    [LogicOverrideIgnoreProperty("_Enabled")]
+    [LogicOverrideIgnoreProperty("_Sequence")]
     public class DefaultLayerHandler : LayerHandler<LayerHandlerProperties>
     {
         public DefaultLayerHandler()

--- a/Project-Aurora/Project-Aurora/Settings/Layers/EqualizerLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/EqualizerLayerHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Aurora.EffectsEngine;
 using Aurora.Profiles;
+using Aurora.Settings.Overrides;
 using Aurora.Utils;
 using NAudio.CoreAudioApi;
 using NAudio.Dsp;
@@ -56,48 +57,47 @@ namespace Aurora.Settings.Layers
 
     public class EqualizerLayerHandlerProperties : LayerHandlerProperties<EqualizerLayerHandlerProperties>
     {
+        [LogicOverridable("Secondary Color")]
         public Color? _SecondaryColor { get; set; }
-
         [JsonIgnore]
         public Color SecondaryColor { get { return Logic._SecondaryColor ?? _SecondaryColor ?? Color.Empty; } }
 
+        [LogicOverridable("Gradient")]
         public EffectBrush _Gradient { get; set; }
-
         [JsonIgnore]
         public EffectBrush Gradient { get { return Logic._Gradient ?? _Gradient ?? new EffectBrush().SetBrushType(EffectBrush.BrushType.Linear); } }
 
+        [LogicOverridable("Equalizer Type")]
         public EqualizerType? _EQType { get; set; }
-
         [JsonIgnore]
         public EqualizerType EQType { get { return Logic._EQType ?? _EQType ?? EqualizerType.PowerBars; } }
 
+        [LogicOverridable("View Type")]
         public EqualizerPresentationType? _ViewType { get; set; }
-
         [JsonIgnore]
         public EqualizerPresentationType ViewType { get { return Logic._ViewType ?? _ViewType ?? EqualizerPresentationType.SolidColor; } }
 
+        [LogicOverridable("Max Amplitude")]
         public float? _MaxAmplitude { get; set; }
-
         [JsonIgnore]
         public float MaxAmplitude { get { return Logic._MaxAmplitude ?? _MaxAmplitude ?? 20.0f; } }
 
+        [LogicOverridable("Scale with System Volume")]
         public bool? _ScaleWithSystemVolume { get; set; }
-
         [JsonIgnore]
         public bool ScaleWithSystemVolume { get { return Logic._ScaleWithSystemVolume ?? _ScaleWithSystemVolume ?? false; } }
 
+        [LogicOverridable("Dim Background on Sound")]
         public bool? _DimBackgroundOnSound { get; set; }
-
         [JsonIgnore]
         public bool DimBackgroundOnSound { get { return Logic._DimBackgroundOnSound ?? _DimBackgroundOnSound ?? false; } }
 
+        [LogicOverridable("Dim Color")]
         public Color? _DimColor { get; set; }
-
         [JsonIgnore]
         public Color DimColor { get { return Logic._DimColor ?? _DimColor ?? Color.Empty; } }
 
         public SortedSet<float> _Frequencies { get; set; }
-
         [JsonIgnore]
         public SortedSet<float> Frequencies { get { return Logic._Frequencies ?? _Frequencies ?? new SortedSet<float>(); } }
 

--- a/Project-Aurora/Project-Aurora/Settings/Layers/GlitchLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/GlitchLayerHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Aurora.EffectsEngine;
 using Aurora.Profiles;
+using Aurora.Settings.Overrides;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -11,6 +12,7 @@ using System.Windows.Controls;
 
 namespace Aurora.Settings.Layers
 {
+    
     public class GlitchLayerHandlerProperties<TProperty> : LayerHandlerProperties2Color<TProperty> where TProperty : GlitchLayerHandlerProperties<TProperty>
     {
         public double? _UpdateInterval { get; set; }
@@ -91,6 +93,9 @@ namespace Aurora.Settings.Layers
         }
     }
 
+    [LogicOverrideIgnoreProperty("_PrimaryColor")]
+    [LogicOverrideIgnoreProperty("_SecondaryColor")]
+    [LogicOverrideIgnoreProperty("_Sequence")]
     public class GlitchLayerHandler : GlitchLayerHandler<GlitchLayerHandlerProperties>
     {
         public GlitchLayerHandler() : base()

--- a/Project-Aurora/Project-Aurora/Settings/Layers/GradientFillLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/GradientFillLayerHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Aurora.EffectsEngine;
 using Aurora.Profiles;
+using Aurora.Settings.Overrides;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -37,6 +38,8 @@ namespace Aurora.Settings.Layers
         }
     }
 
+    [LogicOverrideIgnoreProperty("_PrimaryColor")]
+    [LogicOverrideIgnoreProperty("_SecondaryColor")]
     public class GradientFillLayerHandler : LayerHandler<GradientFillLayerHandlerProperties>
     {
         public GradientFillLayerHandler()

--- a/Project-Aurora/Project-Aurora/Settings/Layers/GradientFillLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/GradientFillLayerHandler.cs
@@ -32,7 +32,7 @@ namespace Aurora.Settings.Layers
         public override void Default()
         {
             base.Default();
-            this._GradientConfig = new LayerEffectConfig(Utils.ColorUtils.GenerateRandomColor(), Utils.ColorUtils.GenerateRandomColor()).SetAnimationType(AnimationType.None);
+            this._GradientConfig = new LayerEffectConfig(Utils.ColorUtils.GenerateRandomColor(), Utils.ColorUtils.GenerateRandomColor()) { AnimationType = AnimationType.None };
             this._FillEntireKeyboard = false;
         }
     }

--- a/Project-Aurora/Project-Aurora/Settings/Layers/GradientLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/GradientLayerHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Aurora.EffectsEngine;
 using Aurora.Profiles;
+using Aurora.Settings.Overrides;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -31,6 +32,8 @@ namespace Aurora.Settings.Layers
         }
     }
 
+    [LogicOverrideIgnoreProperty("_PrimaryColor")]
+    [LogicOverrideIgnoreProperty("_SecondaryColor")]
     public class GradientLayerHandler : LayerHandler<GradientLayerHandlerProperties>
     {
         private EffectLayer temp_layer;

--- a/Project-Aurora/Project-Aurora/Settings/Layers/GradientLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/GradientLayerHandler.cs
@@ -27,7 +27,7 @@ namespace Aurora.Settings.Layers
         public override void Default()
         {
             base.Default();
-            this._GradientConfig = new LayerEffectConfig(Utils.ColorUtils.GenerateRandomColor(), Utils.ColorUtils.GenerateRandomColor()).SetAnimationType(AnimationType.None);
+            this._GradientConfig = new LayerEffectConfig(Utils.ColorUtils.GenerateRandomColor(), Utils.ColorUtils.GenerateRandomColor()) { AnimationType = AnimationType.None };
         }
     }
 

--- a/Project-Aurora/Project-Aurora/Settings/Layers/ImageLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/ImageLayerHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Aurora.EffectsEngine;
 using Aurora.Profiles;
+using Aurora.Settings.Overrides;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -31,6 +32,8 @@ namespace Aurora.Settings.Layers
         }
     }
 
+    [LogicOverrideIgnoreProperty("_PrimaryColor")]
+    [LogicOverrideIgnoreProperty("_SecondaryColor")]
     public class ImageLayerHandler : LayerHandler<ImageLayerHandlerProperties>
     {
         private EffectLayer temp_layer;

--- a/Project-Aurora/Project-Aurora/Settings/Layers/PercentGradientLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/PercentGradientLayerHandler.cs
@@ -14,11 +14,10 @@ namespace Aurora.Settings.Layers
     public class PercentGradientLayerHandlerProperties : PercentLayerHandlerProperties<PercentGradientLayerHandlerProperties>
     {
         public PercentGradientLayerHandlerProperties() : base() { }
-
         public PercentGradientLayerHandlerProperties(bool empty = false) : base(empty) { }
 
+        [Overrides.LogicOverridable("Gradient")]
         public EffectBrush _Gradient { get; set; }
-
         [JsonIgnore]
         public EffectBrush Gradient { get { return Logic._Gradient ?? _Gradient ?? new EffectBrush().SetBrushType(EffectBrush.BrushType.Linear); } }
         

--- a/Project-Aurora/Project-Aurora/Settings/Layers/PercentGradientLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/PercentGradientLayerHandler.cs
@@ -43,38 +43,10 @@ namespace Aurora.Settings.Layers
 
         public override EffectLayer Render(IGameState state)
         {
-            EffectLayer percent_layer = new EffectLayer();
+            double value = Properties.Logic._Value ?? Utils.GameStateUtils.TryGetDoubleFromState(state, Properties.VariablePath);
+            double maxvalue = Properties.Logic._MaxValue ?? Utils.GameStateUtils.TryGetDoubleFromState(state, Properties.MaxVariablePath);
 
-            double value = 0;
-            if (!double.TryParse(Properties._VariablePath, out value) && !string.IsNullOrWhiteSpace(Properties._VariablePath))
-            {
-                try
-                {
-                    value = Convert.ToDouble(Utils.GameStateUtils.RetrieveGameStateParameter(state, Properties._VariablePath));
-                }
-                catch (Exception exc)
-                {
-                    value = 0;
-                }
-            }
-
-
-            double maxvalue = 0;
-            if (!double.TryParse(Properties._MaxVariablePath, out maxvalue) && !string.IsNullOrWhiteSpace(Properties._MaxVariablePath))
-            {
-                try
-                {
-                    maxvalue = Convert.ToDouble(Utils.GameStateUtils.RetrieveGameStateParameter(state, Properties._MaxVariablePath));
-                }
-                catch (Exception exc)
-                {
-                    maxvalue = 0;
-                }
-            }
-
-            percent_layer.PercentEffect(Properties.Gradient.GetColorSpectrum(), Properties.Sequence, value, maxvalue, Properties.PercentType, Properties.BlinkThreshold, Properties.BlinkDirection);
-
-            return percent_layer;
+            return new EffectLayer().PercentEffect(Properties.Gradient.GetColorSpectrum(), Properties.Sequence, value, maxvalue, Properties.PercentType, Properties.BlinkThreshold, Properties.BlinkDirection);
         }
 
         public override void SetApplication(Application profile)

--- a/Project-Aurora/Project-Aurora/Settings/Layers/PercentGradientLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/PercentGradientLayerHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Aurora.EffectsEngine;
 using Aurora.Profiles;
+using Aurora.Settings.Overrides;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -28,6 +29,8 @@ namespace Aurora.Settings.Layers
         }
     }
 
+    [LogicOverrideIgnoreProperty("_PrimaryColor")]
+    [LogicOverrideIgnoreProperty("_SecondaryColor")]
     public class PercentGradientLayerHandler : PercentLayerHandler<PercentGradientLayerHandlerProperties>
     { 
         public PercentGradientLayerHandler() : base()

--- a/Project-Aurora/Project-Aurora/Settings/Layers/PercentLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/PercentLayerHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Aurora.EffectsEngine;
 using Aurora.Profiles;
+using Aurora.Settings.Overrides;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -13,38 +14,49 @@ namespace Aurora.Settings.Layers
 {
     public class PercentLayerHandlerProperties<TProperty> : LayerHandlerProperties2Color<TProperty> where TProperty : PercentLayerHandlerProperties<TProperty>
     {
+        [LogicOverridable("Percent Type")]
         public PercentEffectType? _PercentType { get; set; }
-
         [JsonIgnore]
         public PercentEffectType PercentType { get { return Logic._PercentType ?? _PercentType ?? PercentEffectType.Progressive_Gradual; } }
 
+        [LogicOverridable("Blink Threshold")]
         public double? _BlinkThreshold { get; set; }
-
         [JsonIgnore]
         public double BlinkThreshold { get { return Logic._BlinkThreshold ?? _BlinkThreshold ?? 0.0; } }
 
         public bool? _BlinkDirection { get; set; }
-
-        public bool? _BlinkBackground { get; set; }
-
         [JsonIgnore]
         public bool BlinkDirection { get { return Logic._BlinkDirection ?? _BlinkDirection ?? false; } }
 
+        [LogicOverridable("Blink Background")]
+        public bool? _BlinkBackground { get; set; }
         [JsonIgnore]
         public bool BlinkBackground { get { return Logic._BlinkBackground ?? _BlinkBackground ?? false; } }
 
         public string _VariablePath { get; set; }
-
         [JsonIgnore]
         public string VariablePath { get { return Logic._VariablePath ?? _VariablePath ?? string.Empty; } }
 
         public string _MaxVariablePath { get; set; }
-
         [JsonIgnore]
         public string MaxVariablePath { get { return Logic._MaxVariablePath ?? _MaxVariablePath ?? string.Empty; } }
 
-        public PercentLayerHandlerProperties() : base() { }
 
+        // These two properties work slightly differently to the others. These are special properties that allow for
+        // override the value using the overrides system. These are not displayed/directly editable by the user and 
+        // will not actually store a value (so should be ignored by the JSON serializers). If these have a value (non
+        // null), then they will be used as the value/max value for the percent effect, else the _VariablePath and
+        // _MaxVariablePaths will be resolved.
+        [JsonIgnore]
+        [LogicOverridable("Value")]
+        public double? _Value { get; set; }
+
+        [JsonIgnore]
+        [LogicOverridable("Max Value")]
+        public double? _MaxValue { get; set; }
+
+
+        public PercentLayerHandlerProperties() : base() { }
         public PercentLayerHandlerProperties(bool assign_default = false) : base(assign_default) { }
 
         public override void Default()
@@ -70,36 +82,9 @@ namespace Aurora.Settings.Layers
     {
         public override EffectLayer Render(IGameState state)
         {
-            double value = 0;
-            if (!double.TryParse(Properties.VariablePath, out value) && !string.IsNullOrWhiteSpace(Properties.VariablePath))
-            {
-                try
-                {
-                    value = Convert.ToDouble(Utils.GameStateUtils.RetrieveGameStateParameter(state, Properties.VariablePath));
-                }
-                catch (Exception exc)
-                {
-                    value = 0;
-                    if (Global.isDebug)
-                        throw exc;
-                }
-            }
+            double value = Properties.Logic._Value ?? Utils.GameStateUtils.TryGetDoubleFromState(state, Properties.VariablePath);
+            double maxvalue = Properties.Logic._MaxValue ?? Utils.GameStateUtils.TryGetDoubleFromState(state, Properties.MaxVariablePath);
 
-
-            double maxvalue = 0;
-            if (!double.TryParse(Properties.MaxVariablePath, out maxvalue) && !string.IsNullOrWhiteSpace(Properties.MaxVariablePath))
-            {
-                try
-                {
-                    maxvalue = Convert.ToDouble(Utils.GameStateUtils.RetrieveGameStateParameter(state, Properties.MaxVariablePath));
-                }
-                catch (Exception exc)
-                {
-                    maxvalue = 0;
-                    if (Global.isDebug)
-                        throw exc;
-                }
-            }
             return new EffectLayer().PercentEffect(Properties.PrimaryColor, Properties.SecondaryColor, Properties.Sequence, value, maxvalue, Properties.PercentType, Properties.BlinkThreshold, Properties.BlinkDirection, Properties.BlinkBackground);
         }
 

--- a/Project-Aurora/Project-Aurora/Settings/Layers/ScriptLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/ScriptLayerHandler.cs
@@ -9,6 +9,7 @@ using Aurora.Profiles;
 using Newtonsoft.Json;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using Aurora.Settings.Overrides;
 
 namespace Aurora.Settings.Layers
 {
@@ -40,6 +41,8 @@ namespace Aurora.Settings.Layers
         }
     }
 
+    [LogicOverrideIgnoreProperty("_PrimaryColor")]
+    [LogicOverrideIgnoreProperty("_Sequence")]
     public class ScriptLayerHandler : LayerHandler<ScriptLayerHandlerProperties>, INotifyPropertyChanged
     {
         internal Application profileManager;

--- a/Project-Aurora/Project-Aurora/Settings/Layers/SolidFillLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/SolidFillLayerHandler.cs
@@ -29,6 +29,7 @@ namespace Aurora.Settings.Layers
         }
     }
 
+    [Overrides.LogicOverrideIgnoreProperty("_Sequence")]
     public class SolidFillLayerHandler : LayerHandler<SolidFillLayerHandlerProperties>
     {
         public SolidFillLayerHandler()

--- a/Project-Aurora/Project-Aurora/Settings/Layers/WrapperLightsLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/WrapperLightsLayerHandler.cs
@@ -7,6 +7,7 @@ using Aurora.Profiles;
 using System.Windows.Controls;
 using Newtonsoft.Json;
 using Aurora.Devices;
+using Aurora.Settings.Overrides;
 
 namespace Aurora.Settings.Layers
 {
@@ -55,7 +56,9 @@ namespace Aurora.Settings.Layers
             _CloningMap = new Dictionary<DeviceKeys, KeySequence>();
         }
     }
-
+    
+    [LogicOverrideIgnoreProperty("_PrimaryColor")]
+    [LogicOverrideIgnoreProperty("_Sequence")]
     public class WrapperLightsLayerHandler : LayerHandler<WrapperLightsLayerHandlerProperties>
     {
         internal int[] bitmap = new int[126];

--- a/Project-Aurora/Project-Aurora/Settings/Overrides/Control_OverridesEditor.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Overrides/Control_OverridesEditor.xaml.cs
@@ -144,9 +144,10 @@ namespace Aurora.Settings.Overrides {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture) {
             var imageName = new Dictionary<Type, string> {
                 { typeof(bool), "icons8-checked-checkbox-30.png" },
-                { typeof(float), "icons8-numbers-30.png" },
                 { typeof(int), "icons8-numbers-30.png" },
                 { typeof(long), "icons8-numbers-30.png" },
+                { typeof(float), "icons8-numbers-30.png" },
+                { typeof(double), "icons8-numbers-30.png" },
                 { typeof(Color), "icons8-paint-palette-30.png" },
                 { typeof(KeySequence), "icons8-keyboard-30.png" }
             }.TryGetValue((Type)value, out string val) ? val : "icons8-diamonds-30.png";

--- a/Project-Aurora/Project-Aurora/Settings/Overrides/Logic/Boolean/Boolean_LogicOperators.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Overrides/Logic/Boolean/Boolean_LogicOperators.cs
@@ -25,11 +25,16 @@ namespace Aurora.Settings.Overrides.Logic {
         [JsonProperty]
         public ObservableCollection<IEvaluatableBoolean> SubConditions { get; set; } = new ObservableCollection<IEvaluatableBoolean>();
 
-        public Visual GetControl(Application app) => new Control_SubconditionHolder(this, app, "Require atleast one of the following is true...");
+        [JsonIgnore]
+        private Control_SubconditionHolder control;
+        public Visual GetControl(Application app) => control ?? (control = new Control_SubconditionHolder(this, app, "Require atleast one of the following is true..."));
+
         public bool Evaluate(IGameState gameState) => SubConditions.Any(subcondition => subcondition?.Evaluate(gameState) ?? false);
         object IEvaluatable.Evaluate(IGameState gameState) => Evaluate(gameState);
 
         public void SetApplication(Application application) {
+            if (control != null)
+                control.Application = application;
             foreach (var subcondition in SubConditions)
                 subcondition.SetApplication(application);
         }
@@ -55,11 +60,16 @@ namespace Aurora.Settings.Overrides.Logic {
         [JsonProperty]
         public ObservableCollection<IEvaluatableBoolean> SubConditions { get; set; } = new ObservableCollection<IEvaluatableBoolean>();
 
-        public Visual GetControl(Application app) => new Control_SubconditionHolder(this, app, "Require all of the following are true...");
+        [JsonIgnore]
+        private Control_SubconditionHolder control;
+        public Visual GetControl(Application app) => control ?? (control = new Control_SubconditionHolder(this, app, "Require all of the following are true..."));
+
         public bool Evaluate(IGameState gameState) => SubConditions.All(subcondition => subcondition?.Evaluate(gameState) ?? false);
         object IEvaluatable.Evaluate(IGameState gameState) => Evaluate(gameState);
 
         public void SetApplication(Application application) {
+            if (control != null)
+                control.Application = application;
             foreach (var subcondition in SubConditions)
                 subcondition.SetApplication(application);
         }
@@ -86,11 +96,14 @@ namespace Aurora.Settings.Overrides.Logic {
         [JsonProperty]
         public IEvaluatableBoolean SubCondition { get; set; } = new BooleanConstant();
 
-        public Visual GetControl(Application app) => new Control_ConditionNot(this, app);
+        private Control_ConditionNot control;
+        public Visual GetControl(Application app) => control ?? (control = new Control_ConditionNot(this, app));
+
         public bool Evaluate(IGameState gameState) => !SubCondition.Evaluate(gameState);
         object IEvaluatable.Evaluate(IGameState gameState) => Evaluate(gameState);
 
         public void SetApplication(Application application) {
+           // control.app
             SubCondition?.SetApplication(application);
         }
 

--- a/Project-Aurora/Project-Aurora/Settings/Overrides/Logic/Boolean/Control_BooleanGSINumeric.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Overrides/Logic/Boolean/Control_BooleanGSINumeric.xaml
@@ -13,7 +13,7 @@
         </Grid.ColumnDefinitions>
 
         <ComboBox x:Name="Operand1Cb" Text="{Binding Operand1Path}" IsEditable="True" Grid.Column="0" />
-        <ComboBox x:Name="OperatorCb" SelectedValue="{Binding Operator}" SelectedValuePath="Value" DisplayMemberPath="Label" Grid.Column="1" Margin="6,0" />
+        <ComboBox x:Name="OperatorCb" SelectedValue="{Binding Operator}" SelectedValuePath="Value" DisplayMemberPath="Key" Grid.Column="1" Margin="6,0" />
         <ComboBox x:Name="Operand2Cb" Text="{Binding Operand2Path}" IsEditable="True" Grid.Column="2" />
     </Grid>
 </UserControl>

--- a/Project-Aurora/Project-Aurora/Settings/Overrides/Logic/Boolean/Control_BooleanGSINumeric.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Overrides/Logic/Boolean/Control_BooleanGSINumeric.xaml.cs
@@ -15,13 +15,7 @@ namespace Aurora.Settings.Overrides.Logic {
             InitializeComponent();
             DataContext = context;
             SetApplication(application);
-
-            OperatorCb.ItemsSource = Enum.GetValues(typeof(ComparisonOperator))
-                .Cast<ComparisonOperator>()
-                .Select(op => new {
-                    Label = typeof(ComparisonOperator).GetMember(op.ToString()).FirstOrDefault()?.GetCustomAttribute<DescriptionAttribute>()?.Description,
-                    Value = op
-                });
+            OperatorCb.ItemsSource = Utils.EnumUtils.GetEnumItemsSource<ComparisonOperator>();
         }
 
         internal void SetApplication(Application application) {

--- a/Project-Aurora/Project-Aurora/Settings/Overrides/Logic/Boolean/Control_BooleanNot.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Overrides/Logic/Boolean/Control_BooleanNot.xaml
@@ -7,6 +7,6 @@
              mc:Ignorable="d">
     <Grid>
         <TextBlock Text="!" FontSize="18" VerticalAlignment="Center" />
-        <local:Control_EvaluatablePresenter Expression="{Binding ParentCondition.SubCondition, Mode=TwoWay}" Application="{Binding Application}" EvalType="Boolean" Margin="15,0,0,0" />
+        <local:Control_EvaluatablePresenter Expression="{Binding ParentExpr.SubCondition, Mode=TwoWay}" Application="{Binding Application}" EvalType="Boolean" Margin="15,0,0,0" />
     </Grid>
 </UserControl>

--- a/Project-Aurora/Project-Aurora/Settings/Overrides/Logic/Boolean/Control_BooleanNot.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Overrides/Logic/Boolean/Control_BooleanNot.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Windows;
 using System.Windows.Controls;
 
 namespace Aurora.Settings.Overrides.Logic {
@@ -8,8 +9,25 @@ namespace Aurora.Settings.Overrides.Logic {
     public partial class Control_ConditionNot : UserControl {
         public Control_ConditionNot(BooleanNot context, Profiles.Application application) {
             InitializeComponent();
-            DataContext = new Control_ConditionNot_Context { Application = application, ParentCondition = context };
+            ParentExpr = context;
+            Application = application;
+            ((FrameworkElement)Content).DataContext = this;
         }
+
+        #region Properties/Dependency Properties
+        /// <summary>The parent <see cref="BooleanNot"/> evaluatable of this control.</summary>
+        public BooleanNot ParentExpr { get; }
+        
+        /// <summary>The application context of this control. Is passed to the EvaluatablePresenter children.</summary>
+        public Profiles.Application Application {
+            get => (Profiles.Application)GetValue(ApplicationProperty);
+            set => SetValue(ApplicationProperty, value);
+        }
+
+        /// <summary>The property used as a backing store for the application context.</summary>
+        public static readonly DependencyProperty ApplicationProperty =
+            DependencyProperty.Register("Application", typeof(Profiles.Application), typeof(Control_ConditionNot), new PropertyMetadata(null));
+        #endregion
     }
 
     /// <summary>

--- a/Project-Aurora/Project-Aurora/Settings/Overrides/Logic/Control_BinaryOperationHolder.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Overrides/Logic/Control_BinaryOperationHolder.xaml.cs
@@ -26,12 +26,7 @@ namespace Aurora.Settings.Overrides.Logic {
         /// Creates a new numeric binary operation holder control using the values of the specified enum as the operators item source.
         /// </summary>
         public Control_BinaryOperationHolder(Profiles.Application application, EvaluatableType evalType, Type enumType) : this(application, evalType) {
-            operatorSelection.ItemsSource = Enum.GetValues(enumType)
-                .Cast<object>()
-                .ToDictionary(
-                    op => enumType.GetMember(op.ToString()).FirstOrDefault()?.GetCustomAttribute<DescriptionAttribute>()?.Description ?? op.ToString(),
-                    op => op
-                );
+            operatorSelection.ItemsSource = Utils.EnumUtils.GetEnumItemsSource(enumType);
         }
 
         #region Properties

--- a/Project-Aurora/Project-Aurora/Settings/Overrides/Logic/Control_SublogicHolder.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Overrides/Logic/Control_SublogicHolder.xaml
@@ -7,9 +7,9 @@
              mc:Ignorable="d" 
              d:DesignHeight="200" d:DesignWidth="200">
     <Grid>
-        <Label Content="{Binding Title}" />
+        <Label Content="{Binding Description}" />
 
-        <ItemsControl Margin="12,28,0,26" ItemsSource="{Binding Parent.SubConditions}">
+        <ItemsControl Margin="12,28,0,26" ItemsSource="{Binding ParentExpr.SubConditions}">
             <ItemsControl.ItemTemplate>
                 <DataTemplate>
                     <Grid Margin="6,0,0,6">

--- a/Project-Aurora/Project-Aurora/Settings/Overrides/Logic/Control_SublogicHolder.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Overrides/Logic/Control_SublogicHolder.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.ObjectModel;
+using System.Windows;
 using System.Windows.Controls;
 
 namespace Aurora.Settings.Overrides.Logic {
@@ -7,38 +8,48 @@ namespace Aurora.Settings.Overrides.Logic {
     /// Interaction logic for Control_SubconditionHolder.xaml
     /// </summary>
     public partial class Control_SubconditionHolder : UserControl {
-        public Control_SubconditionHolder(IHasSubConditons parent, Profiles.Application application, string title="") {
+        public Control_SubconditionHolder(IHasSubConditons parent, Profiles.Application app, string description="") {
             InitializeComponent();
-            DataContext = new Control_SubconditionHolder_Context { Parent = parent, Application = application, Title = title };
+            ParentExpr = parent;
+            Application = app;
+            Description = description;
+            ((FrameworkElement)Content).DataContext = this;
         }
 
-        private ObservableCollection<IEvaluatableBoolean> SubConditions => ((Control_SubconditionHolder_Context)DataContext).Parent.SubConditions;
-
-        private void AddSubconditionButton_Click(object sender, System.Windows.RoutedEventArgs e) {
-            SubConditions.Add(new BooleanConstant());
+        private void AddSubconditionButton_Click(object sender, RoutedEventArgs e) {
+            ParentExpr.SubConditions.Add(new BooleanConstant());
         }
 
         // We cannot do a TwoWay binding on the items of an ObservableCollection if that item may be replaced (it would be fine if only the instance's
         // values were being changed), so we have to capture change events and replace them in the list.
         private void ConditionPresenter_ConditionChanged(object sender, ExpressionChangeEventArgs e) {
-            SubConditions[SubConditions.IndexOf((IEvaluatableBoolean)e.OldExpression)] = (IEvaluatableBoolean)e.NewExpression;
+            ParentExpr.SubConditions[ParentExpr.SubConditions.IndexOf((IEvaluatableBoolean)e.OldExpression)] = (IEvaluatableBoolean)e.NewExpression;
         }
 
-        private void DeleteButton_Click(object sender, System.Windows.RoutedEventArgs e) {
+        private void DeleteButton_Click(object sender, RoutedEventArgs e) {
             // The DataContext of the clicked button (which is the sender) is the ICondition since
             // it is created for each item inside the ItemsControl items source.
             // We can then simply call remove on the conditions list to remove it.
-            var cond = (IEvaluatableBoolean)((System.Windows.FrameworkElement)sender).DataContext;
-            SubConditions.Remove(cond);
+            var cond = (IEvaluatableBoolean)((FrameworkElement)sender).DataContext;
+            ParentExpr.SubConditions.Remove(cond);
         }
-    }
 
-    /// <summary>
-    /// The datatype that is used as the DataContext for `Control_SubconditionHolder`.
-    /// </summary>
-    internal class Control_SubconditionHolder_Context {
-        public IHasSubConditons Parent { get; set; }
-        public Profiles.Application Application { get; set; }
-        public string Title { get; set; }
+        #region Properties/Dependency Properties
+        /// <summary>The parent evaluatable of this control. Must be an evaluatable that has sub conditions.</summary>
+        public IHasSubConditons ParentExpr { get; }
+
+        /// <summary>The title/description text of this control.</summary>
+        public string Description { get; }
+
+        /// <summary>The application context of this control. Is passed to the EvaluatablePresenter children.</summary>
+        public Profiles.Application Application {
+            get => (Profiles.Application)GetValue(ApplicationProperty);
+            set => SetValue(ApplicationProperty, value);
+        }
+        
+        /// <summary>The property used as a backing store for the application context.</summary>
+        public static readonly DependencyProperty ApplicationProperty =
+            DependencyProperty.Register("Application", typeof(Profiles.Application), typeof(Control_SubconditionHolder), new PropertyMetadata(null));
+        #endregion
     }
 }

--- a/Project-Aurora/Project-Aurora/Settings/Overrides/Logic/Number/Control_NumericUnaryOpHolder.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Overrides/Logic/Number/Control_NumericUnaryOpHolder.xaml.cs
@@ -23,12 +23,7 @@ namespace Aurora.Settings.Overrides.Logic {
 
         /// <summary>Creates a new unary operation control using the given Enum type as a source for the possible operators to choose from.</summary>
         public Control_NumericUnaryOpHolder(Profiles.Application application, Type enumType) : this(application) {
-            OperatorList = Enum.GetValues(enumType)
-                .Cast<object>()
-                .ToDictionary(
-                    op => enumType.GetMember(op.ToString()).FirstOrDefault()?.GetCustomAttribute<DescriptionAttribute>()?.Description ?? op.ToString(),
-                    op => op
-                );
+            OperatorList = Utils.EnumUtils.GetEnumItemsSource(enumType).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
         }
 
         /// <summary>Creates a new unary opeartion control using the given string as the name of the operator, disallowing the user to choose an option.</summary>

--- a/Project-Aurora/Project-Aurora/Settings/Overrides/LogicOverridableAttribute.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Overrides/LogicOverridableAttribute.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Aurora.Settings.Layers;
+using System;
 
 namespace Aurora.Settings.Overrides {
 
@@ -15,6 +16,31 @@ namespace Aurora.Settings.Overrides {
 
         public LogicOverridableAttribute(string name) {
             Name = name;
+        }
+    }
+
+
+
+    /// <summary>
+    /// Marks that a property in this <see cref="LayerHandler"/>'s properties' inheritance tree should be
+    /// ignored and not shown in the overridable list. This is useful for when properties are incorrectly
+    /// inherited from other <see cref="LayerHandlerProperties"/> classes. This attribute should be applied
+    /// TO THE LAYER HANDLER, NOT THE PROPERTIES. This is because some layer handlers share the same properties
+    /// class, but only on some of the handlers should the properties be hidden. Yes it's a mess, I know.
+    /// <para>This wants to be removed and the inheritance of the properties should be fixed ASAP.</para>
+    /// </summary>
+    #warning This should be removed as soon as possible when the inheritance tree for layer properties is fixed.
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+    public class LogicOverrideIgnorePropertyAttribute : Attribute {
+
+        /// <summary>
+        /// A name of a property (by member name, including the underscore) that should not
+        /// be shown in the overridable list for this LayerHandlerProperties.
+        /// </summary>
+        public string PropertyName { get; }
+
+        public LogicOverrideIgnorePropertyAttribute(string propertyName) {
+            PropertyName = propertyName;
         }
     }
 }

--- a/Project-Aurora/Project-Aurora/Settings/ProfileImporter.cs
+++ b/Project-Aurora/Project-Aurora/Settings/ProfileImporter.cs
@@ -207,7 +207,7 @@ namespace Aurora.Settings {
                                                         {
                                                             _Sequence = affected_keys,
                                                             _PrimaryColor = System.Drawing.ColorTranslator.FromHtml(transitionInfo.Element("value0").Element("color").Value),
-                                                            _Opacity = int.Parse(lightingInfo.Element("ptr_wrapper").Element("data").Element("opacity").Value) / 255.0f
+                                                            _LayerOpacity = int.Parse(lightingInfo.Element("ptr_wrapper").Element("data").Element("opacity").Value) / 255.0f
                                                         },
                                                     }
                                                 });

--- a/Project-Aurora/Project-Aurora/Utils/ColorUtils.cs
+++ b/Project-Aurora/Project-Aurora/Utils/ColorUtils.cs
@@ -350,6 +350,15 @@ namespace Aurora.Utils
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => new RealColor((System.Windows.Media.Color)value);
     }
 
+    /// <summary>
+    /// Class to convert between a <see cref="EffectsEngine.EffectBrush"></see> and a <see cref="System.Windows.Media.Brush"></see> so that it can be
+    /// used with the ColorBox gradient editor control.
+    /// </summary>
+    public class EffectBrushToBrushConverter : IValueConverter {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) => ((EffectsEngine.EffectBrush)value).GetMediaBrush();
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => new EffectsEngine.EffectBrush((System.Windows.Media.Brush)value);
+    }
+
     public class BoolToColorConverter : IValueConverter
     {
         public static Tuple<Color, Color> TextWhiteRed = new Tuple<Color, Color>(Color.FromArgb(255, 186, 186, 186), Color.Red);

--- a/Project-Aurora/Project-Aurora/Utils/EnumUtils.cs
+++ b/Project-Aurora/Project-Aurora/Utils/EnumUtils.cs
@@ -24,6 +24,24 @@ namespace Aurora.Utils
         public static string GetCategory(this Enum enumObj) {
             return enumObj.GetType().GetField(enumObj.ToString()).GetCustomAttribute(typeof(CategoryAttribute), false) is CategoryAttribute attr ? attr.Category : "";
         }
+
+        /// <summary>Takes a particular type of enum and returns all values of the enum and their associated description in a list suitable for use as an ItemsSource.
+        /// Returns an enumerable of KeyValuePairs where the key is the description/name and the value is the enum's value.</summary>
+        /// <typeparam name="T">The type of enum whose values to fetch.</typeparam>
+        public static IEnumerable<KeyValuePair<string, T>> GetEnumItemsSource<T>() =>
+            typeof(T).GetEnumValues().Cast<T>().Select(@enum => new KeyValuePair<string, T>(
+                typeof(T).GetMember(@enum.ToString()).FirstOrDefault()?.GetCustomAttribute<DescriptionAttribute>()?.Description ?? @enum.ToString(),
+                @enum
+            ));
+
+        /// <summary>Takes a particular type of enum and returns all values of the enum and their associated description in a list suitable for use as an ItemsSource.
+        /// Returns an enumerable of KeyValuePairs where the key is the description/name and the value is the enum's value.</summary>
+        /// <param name="enumType">The type of enum whose values to fetch.</param>
+        public static IEnumerable<KeyValuePair<string, object>> GetEnumItemsSource(Type enumType) =>
+            enumType.GetEnumValues().Cast<object>().Select(@enum => new KeyValuePair<string, object>(
+                enumType.GetMember(@enum.ToString()).FirstOrDefault()?.GetCustomAttribute<DescriptionAttribute>()?.Description ?? @enum.ToString(),
+                @enum
+            ));
     }
 
     public static class IValueConverterExt

--- a/Project-Aurora/Project-Aurora/Utils/GameStateUtils.cs
+++ b/Project-Aurora/Project-Aurora/Utils/GameStateUtils.cs
@@ -179,6 +179,7 @@ namespace Aurora.Utils
 
         /// <summary>
         /// Attempts to get a double value from the game state with the given path.
+        /// Will handle converting string literal numbers (e.g. "10") into a double.
         /// Returns 0 if an error occurs
         /// </summary>
         public static double TryGetDoubleFromState(IGameState state, string path) {


### PR DESCRIPTION
This PR attempts to fix a few issues that have been found with the Overrides System. Current known and fixed bugs are:

* [x] Game State dropdowns that are children of and/or expressions being empty
* [x] ~Changing the overrride logic does not trigger a save and so sometimes you can lose progress if you close Aurora immediately after editing the logic.~ According to [this Discord message](https://discordapp.com/channels/427609830073696258/428606931700023299/554318942823251988), it's not an issue with the overrides system in particular, so skipping it in this override fix PR.
* [x] Add exclude keys/regions to all Layers
* [x] Add all properties to the LayerEffectConfig editor
* [x] Improve audio visualizer support (Add secondary color, etc.)
* [x] Add current/maximum value to percent Layers
* [x] Added a **temporary** `LogicOverrideIgnoreProperty` attribute for layer handlers so specify that one or more of their properties should not be shown in the overridable property list. This should be **temporary** until we are able to resolve the layer handler properties' inheritance, which I recommend is done next time there is a change planned that will likely break existing profiles anyways (such as the device layout rework perhaps?).