### PR TITLE
fix of not re enabling "Use Freestyle instead" checkbox

### DIFF
--- a/Project-Aurora/Project-Aurora/Controls/KeySequence.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Controls/KeySequence.xaml.cs
@@ -293,7 +293,8 @@ namespace Aurora.Controls
                 this.sequence_up.IsEnabled = (bool)e.NewValue;
                 this.sequence_down.IsEnabled = (bool)e.NewValue;
                 this.sequence_remove.IsEnabled = (bool)e.NewValue;
-                this.sequence_freestyle_checkbox.IsEnabled = (bool)e.NewValue && FreestyleEnabled;
+                this.sequence_freestyle_checkbox.IsEnabled = (bool)e.NewValue;
+                //this.sequence_freestyle_checkbox.IsEnabled = (bool)e.NewValue && FreestyleEnabled;
 
                 if ((bool)e.NewValue)
                     sequence_updateToLayerEditor();


### PR DESCRIPTION
It seems like it was originally meant to disable the controls when the use Freestyle instead checkbox is checked.

**This pull request proposes the following changes:**
<!-- List changes that this RP includes -->
- fix of not re enabling "Use Freestyle instead" checkbox
- 
- 

**Known issues/To do:**
<!-- List any bugs that are introduced with this PR or anything that needs further development -->
- wrong status at startup
- 
- 
![Exclude Keys bug](https://user-images.githubusercontent.com/37345589/55899716-c39c5c00-5bc5-11e9-8815-bbef7954aadc.gif)
