### PR TITLE
Updated League of Legends patcher with new game path

### DIFF
--- a/Project-Aurora/Project-Aurora/Profiles/LeagueOfLegends/Control_LoL.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/LeagueOfLegends/Control_LoL.xaml.cs
@@ -68,35 +68,20 @@ namespace Aurora.Profiles.LeagueOfLegends
 
                 if (!String.IsNullOrWhiteSpace(lolpath))
                 {
-                    lolpath = Path.Combine(lolpath, "RADS", "solutions", "lol_game_client_sln", "releases");
-                    DirectoryInfo[] dirs = new DirectoryInfo(lolpath).GetDirectories();
-                    if(dirs.Length != 0)
+                    lolpath = Path.Combine(lolpath, "Game");
+                    if (Directory.Exists(lolpath))
                     {
-                        string latestversion = dirs[dirs.Length - 1].ToString();
-                        lolpath = Path.Combine(lolpath, latestversion, "deploy");
-                        if (Directory.Exists(lolpath))
+                        using (BinaryWriter lightfx_wrapper_86 = new BinaryWriter(new FileStream(System.IO.Path.Combine(lolpath, "LightFX.dll"), FileMode.Create)))
                         {
-                            using (BinaryWriter lightfx_wrapper_86 = new BinaryWriter(new FileStream(System.IO.Path.Combine(lolpath, "LightFX.dll"), FileMode.Create)))
-                            {
-                                lightfx_wrapper_86.Write(Properties.Resources.Aurora_LightFXWrapper86);
-                            }
-
-                            MessageBox.Show("Aurora Wrapper Patch for LightFX applied to\r\n" + lolpath);
+                            lightfx_wrapper_86.Write(Properties.Resources.Aurora_LightFXWrapper86);
                         }
+                        MessageBox.Show("Aurora Wrapper Patch for LightFX applied to\r\n" + lolpath);
                     }
-                    else
-                    {
-                        MessageBox.Show("No versions found in\r\n" + lolpath);
-                    }
-                }
-                else
-                {
-                    MessageBox.Show("Could not find League of Legends path");
-                }                   
+                }                
             }
             catch (Exception exc)
             {
-                Global.logger.Error("Leage of Legends path exception: " + exc);
+                Global.logger.Error("League of Legends path exception: " + exc);
             }
         }
 


### PR DESCRIPTION
Fixes #1540

Riot Changed the path of the game executable so aurora doesnt need to apply the patch every game update. This PR applies that change to the path

