### PR TITLE
Updated RE2 (2019) pointers

### DIFF
--- a/Project-Aurora/Project-Aurora/Pointers/ResidentEvil2.json
+++ b/Project-Aurora/Project-Aurora/Pointers/ResidentEvil2.json
@@ -1,21 +1,21 @@
 {
   "HealthMaximum": {
-    "baseAddress": "118163520",
+    "baseAddress": "118072880",
     "pointers": [ "80", "32", "84" ]
   },
 
   "HealthCurrent": {
-    "baseAddress": "118163520",
+    "baseAddress": "118072880",
     "pointers": [ "80", "32", "88" ]
   },
 
   "PlayerPoisoned": {
-    "baseAddress": "118163520",
+    "baseAddress": "118072880",
     "pointers": [ "80", "32", "248", "600" ]
   },
 
   "RankCurrent": {
-    "baseAddress": "118008280",
+    "baseAddress": "118110064",
     "pointers": [ "88" ]
   }
 }


### PR DESCRIPTION
Resident Evil 2 (2019) pointers updated to newest version. Works as intended.