### PR TITLE
Binary Counter Layer

### DIFF
--- a/Project-Aurora/Project-Aurora/Profiles/LightingStateManager.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/LightingStateManager.cs
@@ -173,7 +173,8 @@ namespace Aurora.Profiles
                 new LayerHandlerEntry("Animation", "Animation Layer", typeof(AnimationLayerHandler) ),
                 new LayerHandlerEntry("ToggleKey", "Toggle Key Layer", typeof(ToggleKeyLayerHandler)),
                 new LayerHandlerEntry("Timer", "Timer Layer", typeof(TimerLayerHandler)),
-                new LayerHandlerEntry("Toolbar", "Toolbar Layer", typeof(ToolbarLayerHandler))
+                new LayerHandlerEntry("Toolbar", "Toolbar Layer", typeof(ToolbarLayerHandler)),
+                new LayerHandlerEntry("BinaryCounter", "Binary Counter Layer", typeof(BinaryCounterLayerHandler))
             }, true);
 
             RegisterLayerHandler(new LayerHandlerEntry("WrapperLights", "Wrapper Lighting Layer", typeof(WrapperLightsLayerHandler)), false);

--- a/Project-Aurora/Project-Aurora/Project-Aurora.csproj
+++ b/Project-Aurora/Project-Aurora/Project-Aurora.csproj
@@ -611,6 +611,10 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="Settings\Layers\BinaryCounterLayerHandler.cs" />
+    <Compile Include="Settings\Layers\Control_BinaryCounterLayer.xaml.cs">
+      <DependentUpon>Control_BinaryCounterLayer.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Settings\Overrides\Logic\Boolean\Boolean_PeripheralInput.cs" />
     <Compile Include="Settings\Overrides\Logic\Control_BinaryOperationHolder.xaml.cs">
       <DependentUpon>Control_BinaryOperationHolder.xaml</DependentUpon>
@@ -1199,7 +1203,7 @@
     <None Include="kb_layouts\Plain Keyboard\layout.intl.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-	<None Include="kb_layouts\Plain Keyboard\layout.it.json">
+    <None Include="kb_layouts\Plain Keyboard\layout.it.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="kb_layouts\Plain Keyboard\layout.jpn.json">
@@ -1968,6 +1972,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Profiles\XCOM\Control_XCOM.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Settings\Layers\Control_BinaryCounterLayer.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/Project-Aurora/Project-Aurora/Settings/Layers/BinaryCounterLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/BinaryCounterLayerHandler.cs
@@ -1,0 +1,61 @@
+﻿using Aurora.EffectsEngine;
+using Aurora.Profiles;
+using Aurora.Settings.Overrides;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Controls;
+
+namespace Aurora.Settings.Layers {
+
+    public class BinaryCounterLayerHandlerProperties : LayerHandlerProperties<BinaryCounterLayerHandlerProperties> {
+
+        // The var path of the variable to use (set though the UI, cannot be set with overrides)
+        public string _VariablePath { get; set; }
+        [JsonIgnore]
+        public string VariablePath => Logic._VariablePath ?? _VariablePath ?? "";
+
+        // Allows the value to be directly set using the overrides system
+        [JsonIgnore, LogicOverridable("Value")]
+        public double? _Value { get; set; }
+
+        public BinaryCounterLayerHandlerProperties() : base() { }
+        public BinaryCounterLayerHandlerProperties(bool empty) : base(empty) { }
+
+        public override void Default() {
+            base.Default();
+            _VariablePath = "";
+        }
+    }
+
+
+    public class BinaryCounterLayerHandler : LayerHandler<BinaryCounterLayerHandlerProperties> {
+
+        public BinaryCounterLayerHandler() : base() {
+            _ID = "BinaryCounter";
+        }
+
+        private Control_BinaryCounterLayer control;
+        protected override UserControl CreateControl() => control ?? (control = new Control_BinaryCounterLayer(this));
+
+        public override void SetApplication(Application profile) {
+            base.SetApplication(profile);
+            control?.SetApplication(profile);
+        }
+
+        public override EffectLayer Render(IGameState gamestate) {
+            // Get the current game state value
+            double value = Properties.Logic._Value ?? Utils.GameStateUtils.TryGetDoubleFromState(gamestate, Properties.VariablePath);
+
+            // Set the active key
+            var layer = new EffectLayer("BinaryCounterCustomLayer");
+            for (var i = 0; i < Properties.Sequence.keys.Count; i++)
+                if (((int)value & 1 << i) > 0)
+                    layer.Set(Properties.Sequence.keys[i], Properties.PrimaryColor);
+            return layer;
+        }
+    }
+}

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_BinaryCounterLayer.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_BinaryCounterLayer.xaml
@@ -1,0 +1,42 @@
+﻿<UserControl x:Class="Aurora.Settings.Layers.Control_BinaryCounterLayer"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:utils="clr-namespace:Aurora.Utils"
+             xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
+             xmlns:Controls="clr-namespace:Aurora.Controls"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+
+    <UserControl.Resources>
+        <utils:ColorConverter x:Key="ColorConverter" />
+    </UserControl.Resources>
+    
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="95px" />
+            <ColumnDefinition Width="180px" />
+            <ColumnDefinition Width="14px" />
+            <ColumnDefinition Width="240px"/>
+            <ColumnDefinition />
+        </Grid.ColumnDefinitions>
+
+        <Grid.RowDefinitions>
+            <RowDefinition Height="28px" />
+            <RowDefinition Height="28px" />
+            <RowDefinition />
+        </Grid.RowDefinitions>
+
+        <Label Content="Color:" HorizontalAlignment="Stretch" VerticalAlignment="Center" />
+        <xctk:ColorPicker Grid.Column="1" HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="4,2" Height="24" ColorMode="ColorCanvas" UsingAlphaChannel="True" SelectedColor="{Binding Properties._PrimaryColor, Converter={StaticResource ColorConverter}}" />
+
+        <Label Content="Value Path:" Grid.Row="1" HorizontalAlignment="Stretch" VerticalAlignment="Center" />
+        <ComboBox x:Name="valuePath" Grid.Row="1" Grid.Column="1" Width="178" HorizontalAlignment="Stretch" Margin="4,2" IsEditable="True" Text="{Binding Properties._VariablePath}" />
+
+        <StackPanel Grid.Column="3" Grid.RowSpan="3">
+            <Controls:KeySequence x:Name="sequence" Margin="0,4,0,0" Height="280px" VerticalAlignment="Top" RecordingTag="BinaryCounterLayer" Title="Affected Keys" SequenceUpdated="KeySequence_SequenceUpdated" />
+            <TextBlock Margin="0,8,0,0" Text="Enter the keys in ascending binary order, e.g. the first key will represent the right-most bit." TextWrapping="Wrap" />
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_BinaryCounterLayer.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_BinaryCounterLayer.xaml.cs
@@ -1,0 +1,24 @@
+﻿using System.Linq;
+using System.Windows.Controls;
+
+namespace Aurora.Settings.Layers {
+
+    public partial class Control_BinaryCounterLayer : UserControl {
+
+        public Control_BinaryCounterLayer(BinaryCounterLayerHandler context) {
+            InitializeComponent();
+            SetApplication(context.Application);
+            DataContext = context;
+            sequence.Sequence = context.Properties._Sequence;
+        }
+
+        public void SetApplication(Profiles.Application app) {
+            valuePath.ItemsSource = app.ParameterLookup?.Where(kvp => Utils.TypeUtils.IsNumericType(kvp.Value.Item1)).Select(kvp => kvp.Key);
+        }
+
+        private void KeySequence_SequenceUpdated(object sender, System.EventArgs e) {
+            // Apparently the Controls.KeySequnce wasn't made with DependencyProperties properly as it doesn't work with bindings :(
+            ((BinaryCounterLayerHandler)DataContext).Properties._Sequence = sequence.Sequence;
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a new layer type: the binary counter layer.

It accepts a state variable and displays it on the given key sequence in binary form, with the first key in the list representing the right-most bit, the second key representing the second right-most bit, etc.

The value can also be override through the overrides system, allowing for displaying the results of override operations.

This is related to enhancement #1617.

---

In this example Binary clock, two of these layers have been used with the overrides system to show `CurrentSecond / 10` (in green, showing the units) and `CurrentSecond % 10` (in blue, showing the tens), as a true binary clock would.

![Binary clock example](https://user-images.githubusercontent.com/3984322/60126954-044c5000-9787-11e9-865f-84aac71d5454.gif)
