### PR TITLE
Fixes dota2 ability layer not handling seasonal abilities

### DIFF
--- a/Project-Aurora/Project-Aurora/Profiles/Dota 2/Layers/Dota2AbilityLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/Dota 2/Layers/Dota2AbilityLayerHandler.cs
@@ -71,8 +71,11 @@ namespace Aurora.Profiles.Dota_2.Layers
                     for (int index = 0; index < dota2state.Abilities.Count; index++)
                     {
                         Ability ability = dota2state.Abilities[index];
-                        if (ability.Name.Contains("seasonal"))
+                        if (ability.Name.Contains("seasonal") || ability.Name.Contains("high_five"))
+                        {
+                            index++;
                             continue;
+                        }
                         Devices.DeviceKeys key = Properties.AbilityKeys[index];
 
                         if (ability.IsUltimate)

--- a/Project-Aurora/Project-Aurora/Profiles/Dota 2/Layers/Dota2AbilityLayerHandler.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/Dota 2/Layers/Dota2AbilityLayerHandler.cs
@@ -72,10 +72,8 @@ namespace Aurora.Profiles.Dota_2.Layers
                     {
                         Ability ability = dota2state.Abilities[index];
                         if (ability.Name.Contains("seasonal") || ability.Name.Contains("high_five"))
-                        {
-                            index++;
-                            continue;
-                        }
+                            continue;  
+                        
                         Devices.DeviceKeys key = Properties.AbilityKeys[index];
 
                         if (ability.IsUltimate)


### PR DESCRIPTION
New High five ability and the seasonal abilites break the current ability layer, causing the whole profile to be black.

This skips any ability that isn't relevant (no cooldown).