### PR TITLE
Audio capture checkbox

### DIFF
--- a/Project-Aurora/Project-Aurora/Profiles/GameState.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/GameState.cs
@@ -273,6 +273,7 @@ namespace Aurora.Profiles
         private static System.Timers.Timer cpuCounterTimer;
 
         private static MMDeviceEnumerator mmDeviceEnumerator = new MMDeviceEnumerator();
+        private static NAudio.Wave.WaveInEvent waveInEvent = new NAudio.Wave.WaveInEvent();
 
         /// <summary>
         /// Current CPU Usage
@@ -302,10 +303,22 @@ namespace Aurora.Profiles
                 Global.logger.LogLine("Failed to create PerformanceCounter. Try: https://stackoverflow.com/a/34615451 Exception: " + exc);
             }
 
-            // Without this, the microphone does not activate and therefore the "MicrophoneLevel" property shows 0 unless the user is using
-            // an application that makes use of the microphone.
-            try { new NAudio.Wave.WaveInEvent().StartRecording(); }
-            catch { /* Will error if there is no recording device found. */ }
+            void StartStopRecording() {
+                // We must start recording to be able to capture audio in, but only do this if the user has the option set. Allowing them
+                // to turn it off will give them piece of mind we're not spying on them and will stop the Windows 10 mic icon appearing.
+                try {
+                    if (Global.Configuration.EnableAudioCapture)
+                        waveInEvent.StartRecording();
+                    else
+                        waveInEvent.StopRecording();
+                } catch { }
+            }
+
+            StartStopRecording();
+            Global.Configuration.PropertyChanged += (sender, e) => {
+                if (e.PropertyName == "EnableAudioCapture")
+                    StartStopRecording();
+            };
         }
 
         internal LocalPCInformation() : base()

--- a/Project-Aurora/Project-Aurora/Settings/Configuration.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Configuration.cs
@@ -412,6 +412,9 @@ namespace Aurora.Settings
         private BitmapAccuracy bitmapAccuracy = BitmapAccuracy.Okay;
         public BitmapAccuracy BitmapAccuracy { get { return bitmapAccuracy; } set { bitmapAccuracy = value; InvokePropertyChanged(); } }
 
+        private bool enableAudioCapture;
+        public bool EnableAudioCapture { get => enableAudioCapture; set { enableAudioCapture = value; InvokePropertyChanged(); } }
+
         public bool updates_check_on_start_up;
         public bool start_silently;
         public AppExitMode close_mode;

--- a/Project-Aurora/Project-Aurora/Settings/Control_Settings.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Control_Settings.xaml
@@ -132,10 +132,10 @@
                     <TextBlock HorizontalAlignment="Left" Margin="11,230,0,0" TextWrapping="Wrap" Text="Blackout start time:" VerticalAlignment="Top"/>
                     <TextBlock HorizontalAlignment="Left" Margin="12,254,0,0" TextWrapping="Wrap" Text="Blackout end time:" VerticalAlignment="Top"/>
                     <CheckBox x:Name="timed_dimming_with_games_checkbox" Content="Apply timed blackout to game events" HorizontalAlignment="Left" Margin="10,205,0,0" VerticalAlignment="Top" Checked="timed_dimming_with_games_checkbox_Checked" Unchecked="timed_dimming_with_games_checkbox_Checked"/>
-                    <ListBox x:Name="excluded_listbox" HorizontalAlignment="Left" Height="199" Margin="512,68,0,-15" VerticalAlignment="Top" Width="160"/>
-                    <TextBlock Text="Excluded Processes" HorizontalAlignment="Left" Margin="512,47,0,0" VerticalAlignment="Top" Width="113"/>
-                    <Button x:Name="excluded_add" Content="Add Process" HorizontalAlignment="Left" Margin="677,68,0,0" VerticalAlignment="Top" Click="excluded_add_Click"/>
-                    <Button x:Name="excluded_remove" Content="Remove Process" HorizontalAlignment="Left" Margin="677,96,0,0" VerticalAlignment="Top" Click="excluded_remove_Click"/>
+                    <ListBox x:Name="excluded_listbox" HorizontalAlignment="Left" Height="199" Margin="512,83,0,-30" VerticalAlignment="Top" Width="160"/>
+                    <TextBlock Text="Excluded Processes" HorizontalAlignment="Left" Margin="512,62,0,0" VerticalAlignment="Top" Width="113"/>
+                    <Button x:Name="excluded_add" Content="Add Process" HorizontalAlignment="Left" Margin="677,83,0,0" VerticalAlignment="Top" Click="excluded_add_Click"/>
+                    <Button x:Name="excluded_remove" Content="Remove Process" HorizontalAlignment="Left" Margin="677,111,0,0" VerticalAlignment="Top" Click="excluded_remove_Click"/>
                     <TextBlock HorizontalAlignment="Left" Margin="12,132,0,0" TextWrapping="Wrap" Text="Keyboard brightness modifier: " VerticalAlignment="Top"/>
                     <TextBlock x:Name="lblKeyboardBrightness" HorizontalAlignment="Left" Margin="335,132,0,0" TextWrapping="Wrap" Text="0 %" VerticalAlignment="Top"/>
                     <Slider x:Name="sldKeyboardBrightness" HorizontalAlignment="Left" Margin="180,132,0,0" VerticalAlignment="Top" Width="150" Maximum="1" ValueChanged="sliderPercentages_ValueChanged" Value="{Binding KeyboardBrightness, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Tag="{Binding ElementName=lblKeyboardBrightness, Path=.}"/>
@@ -170,6 +170,7 @@
                     <TextBlock Text="Delay:" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="278,10,0,0" />
                     <xctk:IntegerUpDown x:Name="startDelayAmount" Height="22" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="315,8,0,0" Width="69" Minimum="0" Increment="15" ValueChanged="startDelayAmount_ValueChanged" />
                     <TextBlock Text="sec" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="389,10,0,0" />
+                    <CheckBox Content="Enable Audio Capture (for gamestates)" ToolTip="Aurora only measures the activity level from your microphone for use with the 'LocalPCInfo' game state. None of this data is stored or transmitted elsewhere." HorizontalAlignment="Left" Margin="512,39,0,0" VerticalAlignment="Top" IsChecked="{Binding EnableAudioCapture}" />
                 </Grid>
             </TabItem>
             <TabItem Header="Volume Overlay">


### PR DESCRIPTION
Adds an option to the settings to disable the microphone level gamestate (and thus the Windows 10 "Aurora is using your microphone" notification). This will give people the peace of mind that Aurora isn't spying on them.

It may be possible that Aurora is capable of getting the data without triggering the microphone in it's current state, but I _think_ this is dependent on whether the mic is in use already. Either way, this resolves the microphone notification issue.