### PR TITLE
Added OnActivate and OnDeactivate methods to ILightEvent

### DIFF
--- a/Project-Aurora/Project-Aurora/Profiles/Application.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/Application.cs
@@ -423,6 +423,22 @@ namespace Aurora.Profiles
 
             Config.Event.ResetGameState();
         }
+        
+        public virtual void OnActivate()
+        {
+            if (Disposed)
+                return;
+
+            Config.Event.OnActivate();
+        }
+
+        public virtual void OnDeactivate()
+        {
+            if (Disposed)
+                return;
+
+            Config.Event.OnDeactivate();
+        }
 
         public virtual void UpdateEffectScripts(Queue<EffectLayer> layers, IGameState state = null)
         {

--- a/Project-Aurora/Project-Aurora/Profiles/LightEvent.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/LightEvent.cs
@@ -20,6 +20,10 @@ namespace Aurora.Profiles
 
         void ResetGameState();
 
+        void OnActivate();
+
+        void OnDeactivate();
+
         bool IsEnabled { get; }
 
         LightEventConfig Config { get; }
@@ -79,6 +83,16 @@ namespace Aurora.Profiles
         public virtual void ResetGameState()
         {
             _game_state = new GameState();
+        }
+        
+        public virtual void OnActivate()
+        {
+
+        }
+
+        public virtual void OnDeactivate()
+        {
+
         }
 
         public bool Initialize()


### PR DESCRIPTION
Added OnActivate and OnDeactivate methods which should be called when the profile becomes active/inactive

**This pull request proposes the following changes:**
`ILightEvent` now has two more methods - `OnActivate` and `OnDeactivate` which are called when the Application is being brought to foreground or vice versa.

**Known issues/To do:**
Needs to be tested if new methods are called in all cases
