### PR TITLE
Added new minecraft gsi variable dimensionID and chatguiopen

### DIFF
--- a/Project-Aurora/Project-Aurora/Profiles/Minecraft/GSI/Nodes/GameNode.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/Minecraft/GSI/Nodes/GameNode.cs
@@ -10,11 +10,13 @@ namespace Aurora.Profiles.Minecraft.GSI.Nodes {
 
         public MinecraftKeyBinding[] KeyBindings;
         public bool ControlsGuiOpen;
+        public bool ChatGuiOpen;
 
         internal GameNode() : base() { }
         internal GameNode(string json) : base(json) {
             KeyBindings = GetArray<MinecraftKeyBinding>("keys");
             ControlsGuiOpen = GetBool("controlsGuiOpen");
+            ChatGuiOpen = GetBool("chatGuiOpen");
         }
     }
 }

--- a/Project-Aurora/Project-Aurora/Profiles/Minecraft/GSI/Nodes/WorldNode.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/Minecraft/GSI/Nodes/WorldNode.cs
@@ -11,12 +11,14 @@ namespace Aurora.Profiles.Minecraft.GSI.Nodes {
         public bool IsDayTime;
         public bool IsRaining;
         public float RainStrength;
+        public int DimensionID;
 
         internal WorldNode(string json) : base(json) {
             WorldTime = GetLong("worldTime");
             IsDayTime = GetBool("isDayTime");
             IsRaining = GetBool("isRaining");
             RainStrength = GetFloat("rainStrength");
+            DimensionID = GetInt("dimensionID");
         }
     }
 }

--- a/Project-Aurora/Project-Aurora/Profiles/Minecraft/MinecraftProfile.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/Minecraft/MinecraftProfile.cs
@@ -2,6 +2,9 @@
 using Aurora.Profiles.Minecraft.Layers;
 using Aurora.Settings;
 using Aurora.Settings.Layers;
+using Aurora.Settings.Overrides;
+using Aurora.Settings.Overrides.Logic;
+using Aurora.Settings.Overrides.Logic.Builder;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -103,14 +106,34 @@ namespace Aurora.Profiles.Minecraft {
                         _SecondaryColor = Color.FromArgb(30, 80, 25),
                         _Sequence = new KeySequence(new FreeFormObject(0, -60, 900, 128))
                     }
-                }),
+                }, 
+                new OverrideLogicBuilder()
+                    .SetLookupTable("_PrimaryColor", new OverrideLookupTableBuilder<Color>()
+                        .AddEntry(Color.FromArgb(125,42,123), new BooleanGSINumeric("World/DimensionID", 1))//The End
+                        .AddEntry(Color.FromArgb(255,183,0), new BooleanGSINumeric("World/DimensionID", -1))//Nether
+                    )
+                    .SetLookupTable("_SecondaryColor", new OverrideLookupTableBuilder<Color>()
+                        .AddEntry(Color.FromArgb(49,0,59), new BooleanGSINumeric("World/DimensionID", 1))//The End
+                        .AddEntry(Color.FromArgb(87,83,0), new BooleanGSINumeric("World/DimensionID", -1))//Nether
+                    )
+                ),
 
                 new Layer("Grass Block Side", new MinecraftBackgroundLayerHandler() {
                     Properties = new MinecraftBackgroundLayerHandlerProperties() {
                         _PrimaryColor = Color.FromArgb(125, 70, 15),//(102, 59, 20),
                         _SecondaryColor = Color.FromArgb(80, 50, 25)
                     }
-                })
+                },
+                new OverrideLogicBuilder()
+                    .SetLookupTable("_PrimaryColor", new OverrideLookupTableBuilder<Color>()
+                        .AddEntry(Color.FromArgb(209,232,80), new BooleanGSINumeric("World/DimensionID", 1))//The End
+                        .AddEntry(Color.FromArgb(184,26,0), new BooleanGSINumeric("World/DimensionID", -1))//Nether
+                    )
+                    .SetLookupTable("_SecondaryColor", new OverrideLookupTableBuilder<Color>()
+                        .AddEntry(Color.FromArgb(107,102,49), new BooleanGSINumeric("World/DimensionID", 1))//The End
+                        .AddEntry(Color.FromArgb(59,8,0), new BooleanGSINumeric("World/DimensionID", -1))//Nether
+                    )
+                ),
             };
         }
     }


### PR DESCRIPTION
Adds new boolean variable that lets the user make the keyboard a solid color when typing a message, and added overrides for the background colors to fit in better with the vanilla dimensions. Of course users can add more overrides to any modded dimensions provided they know their id's.

Version 0.2.1 of the GSI mod is needed, and i've updated all the mods to have this. I've also published the updated mods to curseforge and gitlab.
