### PR TITLE
Fixed AnimationMix.GetDuration not returning a correct duration

### DIFF
--- a/Project-Aurora/Project-Aurora/EffectsEngine/Animations/AnimationMix.cs
+++ b/Project-Aurora/Project-Aurora/EffectsEngine/Animations/AnimationMix.cs
@@ -85,12 +85,13 @@ namespace Aurora.EffectsEngine.Animations
         {
             Dictionary<string, AnimationTrack> _local = new Dictionary<string, AnimationTrack>(_tracks);
 
-            float return_val = 0.0f;
-
+            float current_duration, return_val = 0.0f;
+            
             foreach (KeyValuePair<string, AnimationTrack> track in _local)
             {
-                if (track.Value.AnimationDuration > return_val)
-                    return_val = track.Value.AnimationDuration;
+                current_duration = track.Value.GetShift() + track.Value.AnimationDuration;
+                if (current_duration > return_val)
+                    return_val = current_duration;
             }
 
             return return_val;


### PR DESCRIPTION
Currently `AnimationMix.GetDuration()` simply returns the duration of the longest `AnimationTrack` without accounting for track shifts.

This PR fixes this issue.