### PR TITLE
(Percent Effect Layer) Add support for blink background when freeform is used

### DIFF
--- a/Project-Aurora/Project-Aurora/EffectsEngine/EffectLayer.cs
+++ b/Project-Aurora/Project-Aurora/EffectsEngine/EffectLayer.cs
@@ -685,7 +685,7 @@ namespace Aurora.EffectsEngine
             if (sequence.type == KeySequenceType.Sequence)
                 PercentEffect(foregroundColor, backgroundColor, sequence.keys.ToArray(), value, total, percentEffectType, flash_past, flash_reversed, blink_background);
             else
-                PercentEffect(foregroundColor, backgroundColor, sequence.freeform, value, total, percentEffectType, flash_past, flash_reversed);
+                PercentEffect(foregroundColor, backgroundColor, sequence.freeform, value, total, percentEffectType, flash_past, flash_reversed, blink_background);
 
             return this;
         }
@@ -863,7 +863,7 @@ namespace Aurora.EffectsEngine
                     if(!blink_background)
                         foregroundColor = Utils.ColorUtils.BlendColors(backgroundColor, foregroundColor, Math.Sin((Utils.Time.GetMillisecondsSinceEpoch() % 1000.0D) / 1000.0D * Math.PI));
                     if(blink_background)
-                        backgroundColor = Utils.ColorUtils.BlendColors(backgroundColor, foregroundColor, Math.Sin((Utils.Time.GetMillisecondsSinceEpoch() % 1000.0D) / 1000.0D * Math.PI));
+                        backgroundColor = Utils.ColorUtils.BlendColors(backgroundColor, Color.FromArgb(0, 0, 0, 0), Math.Sin((Utils.Time.GetMillisecondsSinceEpoch() % 1000.0D) / 1000.0D * Math.PI));
                 }
             }
 


### PR DESCRIPTION
<!-- List changes that this RP includes -->
- Enable blink Background if you are using a freestyle sellection
- 
- 

**Known issues:/To do:**
<!-- List any bugs that are introduced with this PR or anything that needs further development -->
- Blink will work different depending if you use freestyle or keylist

![Percent effect Layer alpha blink](https://user-images.githubusercontent.com/37345589/64134408-00b7f380-cdde-11e9-83fc-985434bf1f1d.gif)

