### PR TITLE
Fixed League of legends patch button

### DIFF
--- a/Project-Aurora/Project-Aurora/Profiles/LeagueOfLegends/Control_LoL.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/LeagueOfLegends/Control_LoL.xaml.cs
@@ -62,23 +62,29 @@ namespace Aurora.Profiles.LeagueOfLegends
             {
                 lolpath = String.Empty;
             }
-
-            if (!string.IsNullOrWhiteSpace(lolpath))
+            try
             {
-                lolpath = Path.Combine(lolpath, "Game");
-                if (Directory.Exists(lolpath))
+                if (!string.IsNullOrWhiteSpace(lolpath))
                 {
-                    using (BinaryWriter lightfx_wrapper_86 = new BinaryWriter(new FileStream(Path.Combine(lolpath, "LightFX.dll"), FileMode.Create)))
+                    lolpath = Path.Combine(lolpath, "Game");
+                    if (Directory.Exists(lolpath))
                     {
-                        lightfx_wrapper_86.Write(Properties.Resources.Aurora_LightFXWrapper86);
+                        using (BinaryWriter lightfx_wrapper_86 = new BinaryWriter(new FileStream(Path.Combine(lolpath, "LightFX.dll"), FileMode.Create)))
+                        {
+                            lightfx_wrapper_86.Write(Properties.Resources.Aurora_LightFXWrapper86);
+                        }
+                        MessageBox.Show("Aurora Wrapper Patch for LightFX applied to\r\n" + lolpath);
+                        return;
                     }
-                    MessageBox.Show("Aurora Wrapper Patch for LightFX applied to\r\n" + lolpath);
-                    return;
                 }
+                MessageBox.Show("Couldn't find League of Legends path automatically, please patch manually");
+                return;
             }
-
-            MessageBox.Show("Couldn't find League of Legends path automatically, please patch manually");
-            return;
+            catch(Exception exc)
+            {
+                Global.logger.Error("Error patching League of Legends:" + exc.Message);
+                MessageBox.Show("Error patching League of Legends: " + exc.Message);
+            }
         }
 
         private void game_enabled_Checked(object sender, RoutedEventArgs e)

--- a/Project-Aurora/Project-Aurora/Profiles/LeagueOfLegends/Control_LoL.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/LeagueOfLegends/Control_LoL.xaml.cs
@@ -53,36 +53,32 @@ namespace Aurora.Profiles.LeagueOfLegends
 
         private void patch_button_Click(object sender, RoutedEventArgs e)
         {
+            string lolpath;
             try
             {
-                string lolpath = "";
-
-                try
-                {
-                    lolpath = (string)Microsoft.Win32.Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Riot Games, Inc\League of Legends", "Location", null);
-                }
-                catch (Exception exc)
-                {
-                    lolpath = "";
-                }
-
-                if (!String.IsNullOrWhiteSpace(lolpath))
-                {
-                    lolpath = Path.Combine(lolpath, "Game");
-                    if (Directory.Exists(lolpath))
-                    {
-                        using (BinaryWriter lightfx_wrapper_86 = new BinaryWriter(new FileStream(System.IO.Path.Combine(lolpath, "LightFX.dll"), FileMode.Create)))
-                        {
-                            lightfx_wrapper_86.Write(Properties.Resources.Aurora_LightFXWrapper86);
-                        }
-                        MessageBox.Show("Aurora Wrapper Patch for LightFX applied to\r\n" + lolpath);
-                    }
-                }                
+                lolpath = (string)Microsoft.Win32.Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Riot Games, Inc\League of Legends", "Location", null);
             }
-            catch (Exception exc)
+            catch
             {
-                Global.logger.Error("League of Legends path exception: " + exc);
+                lolpath = String.Empty;
             }
+
+            if (!string.IsNullOrWhiteSpace(lolpath))
+            {
+                lolpath = Path.Combine(lolpath, "Game");
+                if (Directory.Exists(lolpath))
+                {
+                    using (BinaryWriter lightfx_wrapper_86 = new BinaryWriter(new FileStream(Path.Combine(lolpath, "LightFX.dll"), FileMode.Create)))
+                    {
+                        lightfx_wrapper_86.Write(Properties.Resources.Aurora_LightFXWrapper86);
+                    }
+                    MessageBox.Show("Aurora Wrapper Patch for LightFX applied to\r\n" + lolpath);
+                    return;
+                }
+            }
+
+            MessageBox.Show("Couldn't find League of Legends path automatically, please patch manually");
+            return;
         }
 
         private void game_enabled_Checked(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Was failing silently if something went wrong, should now show a message box if it doesn't find the path and log if it fails to write the dll or something similar.