### PR TITLE
Audio Device Picker

### DIFF
--- a/Project-Aurora/Project-Aurora/Project-Aurora.csproj
+++ b/Project-Aurora/Project-Aurora/Project-Aurora.csproj
@@ -790,6 +790,7 @@
     <Compile Include="Settings\Window_ProcessSelection.xaml.cs">
       <DependentUpon>Window_ProcessSelection.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Utils\AudioUtils.cs" />
     <Compile Include="Utils\Converters.cs" />
     <Compile Include="Utils\DesktopUtils.cs" />
     <Compile Include="Utils\DesktopDuplicator.cs" />

--- a/Project-Aurora/Project-Aurora/Settings/ApplicationProfile.cs
+++ b/Project-Aurora/Project-Aurora/Settings/ApplicationProfile.cs
@@ -18,6 +18,13 @@ namespace Aurora.Settings
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
+        protected void SetAndInvoke<T>(ref T field, T value, [CallerMemberName] string propertyName = null) {
+            if (!Equals(field, value)) {
+                field = value;
+                InvokePropertyChanged(propertyName);
+            }
+        }
+
         public object Clone()
         {
             string str = JsonConvert.SerializeObject(this, Formatting.None, new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.All, Binder = Aurora.Utils.JSONUtils.SerializationBinder });

--- a/Project-Aurora/Project-Aurora/Settings/Configuration.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Configuration.cs
@@ -8,6 +8,7 @@ using System.Text;
 using Aurora.Profiles.Generic_Application;
 using Aurora.Profiles;
 using Newtonsoft.Json.Serialization;
+using Aurora.Utils;
 
 namespace Aurora.Settings
 {
@@ -414,8 +415,16 @@ namespace Aurora.Settings
         private BitmapAccuracy bitmapAccuracy = BitmapAccuracy.Okay;
         public BitmapAccuracy BitmapAccuracy { get { return bitmapAccuracy; } set { bitmapAccuracy = value; InvokePropertyChanged(); } }
 
+        #region Audio
         private bool enableAudioCapture;
-        public bool EnableAudioCapture { get => enableAudioCapture; set { enableAudioCapture = value; InvokePropertyChanged(); } }
+        public bool EnableAudioCapture { get => enableAudioCapture; set => SetAndInvoke(ref enableAudioCapture, value); }
+
+        private string audioCaptureDeviceName = AudioUtils.DEVICE_DEFAULT;
+        public string AudioCaptureDeviceName { get => audioCaptureDeviceName; set => SetAndInvoke(ref audioCaptureDeviceName, value); }
+
+        private string audioRenderDeviceName = AudioUtils.DEVICE_DEFAULT;
+        public string AudioRenderDeviceName { get => audioRenderDeviceName; set => SetAndInvoke(ref audioRenderDeviceName, value); }
+        #endregion
 
         public bool updates_check_on_start_up;
         public bool start_silently;

--- a/Project-Aurora/Project-Aurora/Settings/Control_Settings.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Control_Settings.xaml
@@ -8,9 +8,10 @@
              xmlns:EnumDeviceKeys="clr-namespace:Aurora.Devices"
              xmlns:EnumPercentEffectType="clr-namespace:Aurora.Settings"
              xmlns:EnumInteractiveEffects="clr-namespace:Aurora.Profiles.Desktop"
-             xmlns:EnumValueConverters="clr-namespace:Aurora.Utils"
+             xmlns:u="clr-namespace:Aurora.Utils"
              xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
-             xmlns:Controls="clr-namespace:Aurora.Controls" xmlns:params="http://schemas.codeplex.com/elysium/params" x:Class="Aurora.Settings.Control_Settings"
+             xmlns:Controls="clr-namespace:Aurora.Controls" xmlns:params="http://schemas.codeplex.com/elysium/params"
+    xmlns:l="clr-namespace:Aurora.Settings.Layers" x:Class="Aurora.Settings.Control_Settings"
              mc:Ignorable="d"
              d:DesignHeight="400" d:DesignWidth="403.521" Height="Auto" Width="Auto" MinHeight="300" MinWidth="850" Loaded="UserControl_Loaded" Unloaded="UserControl_Unloaded" x:Name="ctrlSettings">
     <UserControl.Resources>
@@ -20,12 +21,12 @@
                     <x:Type TypeName="EnumPercentEffectType:PercentEffectType" />
                 </ObjectDataProvider.MethodParameters>
             </ObjectDataProvider>
-            <EnumValueConverters:PercentEffectTypeToStringVC x:Key="PercentEffectTypeToStringVC"/>
+            <u:PercentEffectTypeToStringVC x:Key="PercentEffectTypeToStringVC"/>
             <DataTemplate x:Key="PercentEffectTypeTemplate">
                 <TextBlock Text="{Binding Converter={StaticResource PercentEffectTypeToStringVC}}" />
             </DataTemplate>
 
-            <EnumValueConverters:DeviceKeysToStringVC x:Key="DeviceKeysToStringVC"/>
+            <u:DeviceKeysToStringVC x:Key="DeviceKeysToStringVC"/>
             <DataTemplate x:Key="DeviceKeys">
                 <TextBlock Text="{Binding Converter={StaticResource DeviceKeysToStringVC}}" />
             </DataTemplate>
@@ -35,7 +36,7 @@
                     <x:Type TypeName="EnumPercentEffectType:IdleEffects" />
                 </ObjectDataProvider.MethodParameters>
             </ObjectDataProvider>
-            <EnumValueConverters:IdleEffectsToStringVC x:Key="IdleEffectsToStringVC"/>
+            <u:IdleEffectsToStringVC x:Key="IdleEffectsToStringVC"/>
             <DataTemplate x:Key="IdleEffectsTemplate">
                 <TextBlock Text="{Binding Converter={StaticResource IdleEffectsToStringVC}}" />
             </DataTemplate>
@@ -45,7 +46,7 @@
                     <x:Type TypeName="local:PreferredKeyboardLocalization" />
                 </ObjectDataProvider.MethodParameters>
             </ObjectDataProvider>
-            <EnumValueConverters:KbLayoutToStringVC x:Key="KbLayoutToStringVC"/>
+            <u:KbLayoutToStringVC x:Key="KbLayoutToStringVC"/>
             <DataTemplate x:Key="KbLayoutTemplate">
                 <TextBlock Text="{Binding Converter={StaticResource KbLayoutToStringVC}}" />
             </DataTemplate>
@@ -55,7 +56,7 @@
                     <x:Type TypeName="local:PreferredKeyboard" />
                 </ObjectDataProvider.MethodParameters>
             </ObjectDataProvider>
-            <EnumValueConverters:KbBrandToStringVC x:Key="KbBrandToStringVC"/>
+            <u:KbBrandToStringVC x:Key="KbBrandToStringVC"/>
             <DataTemplate x:Key="KbBrandTemplate">
                 <TextBlock Text="{Binding Converter={StaticResource KbBrandToStringVC}}" />
             </DataTemplate>
@@ -65,7 +66,7 @@
                     <x:Type TypeName="local:PreferredMouse" />
                 </ObjectDataProvider.MethodParameters>
             </ObjectDataProvider>
-            <EnumValueConverters:MouseBrandToStringVC x:Key="MouseBrandToStringVC"/>
+            <u:MouseBrandToStringVC x:Key="MouseBrandToStringVC"/>
             <DataTemplate x:Key="MouseBrandTemplate">
                 <TextBlock Text="{Binding Converter={StaticResource MouseBrandToStringVC}}" />
             </DataTemplate>
@@ -75,7 +76,7 @@
                     <x:Type TypeName="local:MouseOrientationType" />
                 </ObjectDataProvider.MethodParameters>
             </ObjectDataProvider>
-            <EnumValueConverters:MouseOrientationToStringVC x:Key="MouseOrientationToStringVC"/>
+            <u:MouseOrientationToStringVC x:Key="MouseOrientationToStringVC"/>
             <DataTemplate x:Key="MouseOrientationTemplate">
                 <TextBlock Text="{Binding Converter={StaticResource MouseOrientationToStringVC}}" />
             </DataTemplate>
@@ -85,7 +86,7 @@
                     <x:Type TypeName="local:KeycapType" />
                 </ObjectDataProvider.MethodParameters>
             </ObjectDataProvider>
-            <EnumValueConverters:KeycapTypeToStringVC x:Key="KeycapTypeToStringVC"/>
+            <u:KeycapTypeToStringVC x:Key="KeycapTypeToStringVC"/>
             <DataTemplate x:Key="KeycapTypeTemplate">
                 <TextBlock Text="{Binding Converter={StaticResource KeycapTypeToStringVC}}" />
             </DataTemplate>
@@ -95,7 +96,7 @@
                     <x:Type TypeName="local:BitmapAccuracy" />
                 </ObjectDataProvider.MethodParameters>
             </ObjectDataProvider>
-            <EnumValueConverters:BitmapAccuracyToStringVC x:Key="BitmapAccuracyToStringVC"/>
+            <u:BitmapAccuracyToStringVC x:Key="BitmapAccuracyToStringVC"/>
             <DataTemplate x:Key="BitmapAccuracyTemplate">
                 <TextBlock Text="{Binding Converter={StaticResource BitmapAccuracyToStringVC}}" />
             </DataTemplate>
@@ -105,7 +106,7 @@
                     <x:Type TypeName="local:AppExitMode" />
                 </ObjectDataProvider.MethodParameters>
             </ObjectDataProvider>
-            <EnumValueConverters:appexitmodeToStringVC x:Key="appexitmodeToStringVC"/>
+            <u:appexitmodeToStringVC x:Key="appexitmodeToStringVC"/>
             <DataTemplate x:Key="appexitmodeTemplate">
                 <TextBlock Text="{Binding Converter={StaticResource appexitmodeToStringVC}}" />
             </DataTemplate>
@@ -115,10 +116,12 @@
                     <x:Type TypeName="local:ApplicationDetectionMode" />
                 </ObjectDataProvider.MethodParameters>
             </ObjectDataProvider>
-            <EnumValueConverters:AppDetectionModeToStringVC x:Key="AppDetectionModeToStringVC"/>
+            <u:AppDetectionModeToStringVC x:Key="AppDetectionModeToStringVC"/>
             <DataTemplate x:Key="AppDetectionModeTemplate">
                 <TextBlock Text="{Binding Converter={StaticResource AppDetectionModeToStringVC}}" />
             </DataTemplate>
+
+            <l:DeviceNameCollectionPrependDefaultConverter x:Key="DeviceNameCollectionPrependDefaultConv" />
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -132,10 +135,10 @@
                     <TextBlock HorizontalAlignment="Left" Margin="11,230,0,0" TextWrapping="Wrap" Text="Blackout start time:" VerticalAlignment="Top"/>
                     <TextBlock HorizontalAlignment="Left" Margin="12,254,0,0" TextWrapping="Wrap" Text="Blackout end time:" VerticalAlignment="Top"/>
                     <CheckBox x:Name="timed_dimming_with_games_checkbox" Content="Apply timed blackout to game events" HorizontalAlignment="Left" Margin="10,205,0,0" VerticalAlignment="Top" Checked="timed_dimming_with_games_checkbox_Checked" Unchecked="timed_dimming_with_games_checkbox_Checked"/>
-                    <ListBox x:Name="excluded_listbox" HorizontalAlignment="Left" Height="199" Margin="512,83,0,-30" VerticalAlignment="Top" Width="160"/>
-                    <TextBlock Text="Excluded Processes" HorizontalAlignment="Left" Margin="512,62,0,0" VerticalAlignment="Top" Width="113"/>
-                    <Button x:Name="excluded_add" Content="Add Process" HorizontalAlignment="Left" Margin="677,83,0,0" VerticalAlignment="Top" Click="excluded_add_Click"/>
-                    <Button x:Name="excluded_remove" Content="Remove Process" HorizontalAlignment="Left" Margin="677,111,0,0" VerticalAlignment="Top" Click="excluded_remove_Click"/>
+                    <ListBox x:Name="excluded_listbox" HorizontalAlignment="Left" Height="118" Margin="512,164,0,0" VerticalAlignment="Top" Width="160"/>
+                    <TextBlock Text="Excluded Processes" HorizontalAlignment="Left" Margin="512,143,0,0" VerticalAlignment="Top" Width="113"/>
+                    <Button x:Name="excluded_add" Content="Add Process" HorizontalAlignment="Left" Margin="677,164,0,0" VerticalAlignment="Top" Click="excluded_add_Click"/>
+                    <Button x:Name="excluded_remove" Content="Remove Process" HorizontalAlignment="Left" Margin="677,189,0,0" VerticalAlignment="Top" Click="excluded_remove_Click"/>
                     <TextBlock HorizontalAlignment="Left" Margin="12,132,0,0" TextWrapping="Wrap" Text="Keyboard brightness modifier: " VerticalAlignment="Top"/>
                     <TextBlock x:Name="lblKeyboardBrightness" HorizontalAlignment="Left" Margin="335,132,0,0" TextWrapping="Wrap" Text="0 %" VerticalAlignment="Top"/>
                     <Slider x:Name="sldKeyboardBrightness" HorizontalAlignment="Left" Margin="180,132,0,0" VerticalAlignment="Top" Width="150" Maximum="1" ValueChanged="sliderPercentages_ValueChanged" Value="{Binding KeyboardBrightness, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Tag="{Binding ElementName=lblKeyboardBrightness, Path=.}"/>
@@ -170,7 +173,18 @@
                     <TextBlock Text="Delay:" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="278,10,0,0" />
                     <xctk:IntegerUpDown x:Name="startDelayAmount" Height="22" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="315,8,0,0" Width="69" Minimum="0" Increment="15" ValueChanged="startDelayAmount_ValueChanged" />
                     <TextBlock Text="sec" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="389,10,0,0" />
-                    <CheckBox Content="Enable Audio Capture (for gamestates)" ToolTip="Aurora only measures the activity level from your microphone for use with the 'LocalPCInfo' game state. None of this data is stored or transmitted elsewhere." HorizontalAlignment="Left" Margin="512,39,0,0" VerticalAlignment="Top" IsChecked="{Binding EnableAudioCapture}" />
+                    
+                    <GroupBox Header="Audio Devices" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="508,39,0,0" Width="322" Height="99">
+                        <Grid>
+                            <CheckBox Content="Enable Audio Capture" IsChecked="{Binding EnableAudioCapture}" ToolTip="" Margin="-2,2,0,0" HorizontalAlignment="Left" VerticalAlignment="Top" />
+                            <TextBlock Text="Playback Device:" Margin="4,25,0,0" HorizontalAlignment="Left" VerticalAlignment="Top" />
+                            <ComboBox SelectedItem="{Binding AudioRenderDeviceName}" ItemsSource="{Binding Source={x:Static u:AudioUtils.PlaybackDevices}, Converter={StaticResource DeviceNameCollectionPrependDefaultConv}}" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="96,24,0,0" Width="208" />
+
+                            <TextBlock Text="Capture Device:" Margin="4,54,0,-1" HorizontalAlignment="Left" VerticalAlignment="Top" />
+                            <ComboBox SelectedItem="{Binding AudioCaptureDeviceName}" ItemsSource="{Binding Source={x:Static u:AudioUtils.RecordingDevices}, Converter={StaticResource DeviceNameCollectionPrependDefaultConv}}" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="92,51,0,-4" Width="212" />
+                        </Grid>
+                    </GroupBox>
+                    <Image ToolTip="These settings affect the capture of values for the 'LocalPCInfo' GameState. Aurora only measures the activity level in realtime, none of this data is stored or transmitted elsewhere. Note that some layers (such as the Audio Visualizer) do not use these settings." Source="/Aurora;component/Resources/info.png" ToolTipService.InitialShowDelay="0" Margin="606,41,0,0" HorizontalAlignment="Left" VerticalAlignment="Top" Width="16" Height="16" />
                 </Grid>
             </TabItem>
             <TabItem Header="Volume Overlay">

--- a/Project-Aurora/Project-Aurora/Settings/Control_Settings.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Control_Settings.xaml
@@ -176,10 +176,9 @@
                     
                     <GroupBox Header="Audio Devices" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="508,39,0,0" Width="322" Height="99">
                         <Grid>
-                            <CheckBox Content="Enable Audio Capture" IsChecked="{Binding EnableAudioCapture}" ToolTip="" Margin="-2,2,0,0" HorizontalAlignment="Left" VerticalAlignment="Top" />
+                            <CheckBox Content="Enable Audio Capture" IsChecked="{Binding EnableAudioCapture}" Margin="-2,2,0,0" HorizontalAlignment="Left" VerticalAlignment="Top" ToolTip="Note that when disabling input capture, a restart may be required" ToolTipService.InitialShowDelay="0" />
                             <TextBlock Text="Playback Device:" Margin="4,25,0,0" HorizontalAlignment="Left" VerticalAlignment="Top" />
                             <ComboBox SelectedItem="{Binding AudioRenderDeviceName}" ItemsSource="{Binding Source={x:Static u:AudioUtils.PlaybackDevices}, Converter={StaticResource DeviceNameCollectionPrependDefaultConv}}" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="96,24,0,0" Width="208" />
-
                             <TextBlock Text="Capture Device:" Margin="4,54,0,-1" HorizontalAlignment="Left" VerticalAlignment="Top" />
                             <ComboBox SelectedItem="{Binding AudioCaptureDeviceName}" ItemsSource="{Binding Source={x:Static u:AudioUtils.RecordingDevices}, Converter={StaticResource DeviceNameCollectionPrependDefaultConv}}" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="92,51,0,-4" Width="212" />
                         </Grid>

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_EqualizerLayer.xaml
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_EqualizerLayer.xaml
@@ -9,6 +9,7 @@
              xmlns:EnumValueConverters="clr-namespace:Aurora.Utils" 
              xmlns:local="clr-namespace:Aurora.Settings.Layers"
              xmlns:c="clr-namespace:Aurora.Controls"
+             xmlns:u="clr-namespace:Aurora.Utils"
              mc:Ignorable="d" Loaded="UserControl_Loaded">
     <UserControl.Resources>
         <ResourceDictionary>
@@ -42,6 +43,7 @@
                 <TextBlock Text="{Binding Converter={StaticResource EqualizerBackgroundModeToStringVC}}" />
             </DataTemplate>
 
+            <local:DeviceNameCollectionPrependDefaultConverter x:Key="DeviceNameCollectionPrependDefaultConv" />
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -90,5 +92,8 @@
         <Button x:Name="btn_ShowPreviewWindow" Content="Show Preview Window" HorizontalAlignment="Left" Margin="0,220,0,-2" VerticalAlignment="Top" Click="btn_ShowPreviewWindow_Click"/>
 
         <c:KeySequence x:Name="affectedKeys" Title="Affected Rectangle" RecordingTag="EqAffectedRect" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="511,7,0,0" SequenceUpdated="KeySequence_keys_SequenceUpdated" />
+
+        <TextBlock HorizontalAlignment="Left" Margin="511,131,0,0" Text="Audio Device" VerticalAlignment="Top"/>
+        <ComboBox SelectedItem="{Binding Properties.SelectedAudioDevice}" ItemsSource="{Binding Source={x:Static u:AudioUtils.PlaybackDevices}, Converter={StaticResource DeviceNameCollectionPrependDefaultConv}}" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="586,128,0,0" Width="155" />
     </Grid>
 </UserControl>

--- a/Project-Aurora/Project-Aurora/Settings/Layers/Control_EqualizerLayer.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Layers/Control_EqualizerLayer.xaml.cs
@@ -1,6 +1,10 @@
 using Aurora.EffectsEngine;
+using Aurora.Utils;
+using NAudio.CoreAudioApi;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -36,7 +40,6 @@ namespace Aurora.Settings.Layers
         public Control_EqualizerLayer(EqualizerLayerHandler datacontext)
         {
             InitializeComponent();
-
             this.DataContext = datacontext;
         }
 
@@ -273,5 +276,13 @@ namespace Aurora.Settings.Layers
                 Global.logger.Warn(ex.ToString());
             }
         }
+    }
+
+    public class DeviceNameCollectionPrependDefaultConverter : IValueConverter {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) =>
+            new[] { AudioUtils.DEVICE_DEFAULT } // Add a default option to the start of the list
+            .Concat((ObservableCollection<string>)value);
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
     }
 }

--- a/Project-Aurora/Project-Aurora/Utils/AudioUtils.cs
+++ b/Project-Aurora/Project-Aurora/Utils/AudioUtils.cs
@@ -1,0 +1,92 @@
+﻿using NAudio.CoreAudioApi;
+using NAudio.Wave;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace Aurora.Utils {
+
+    public class AudioDevice : IDisposable {
+
+        private readonly DataFlow flow;
+        private string deviceName;
+        private WasapiLoopbackCapture waveIn;
+        private EventHandler<WaveInEventArgs> waveInDataAvailable; // Store the current event listeners so when device changes, we can re-attach listeners
+
+        public AudioDevice(DataFlow flow) {
+            this.flow = flow;
+        }
+
+        public event EventHandler<WaveInEventArgs> WaveInDataAvailable {
+            add {
+                waveInDataAvailable += value; // Update stored event listeners
+                if (waveIn != null) waveIn.DataAvailable += value; // If WaveIn is valid, pass the event handler on
+            }
+            remove {
+                waveInDataAvailable -= value; // Update stored event listeners
+                if (waveIn != null) waveIn.DataAvailable -= value; // If WaveIn is valid, pass the event handler on
+            }
+        }
+
+        public string DeviceName {
+            get => deviceName;
+            set {
+                if (deviceName == value) return; // Do not re-create the MMDevice is it's not changed
+                deviceName = value;
+                SetupDevice();
+            }
+        }
+
+        public MMDevice Device { get; private set; }
+
+        private void SetupDevice() {
+            DisposeDeviceAndWaveIn();
+
+            // Re-create device
+            Device = string.IsNullOrEmpty(deviceName) || deviceName == AudioUtils.DEVICE_DEFAULT
+                ? AudioUtils.DeviceEnumerator.GetDefaultAudioEndpoint(flow, Role.Multimedia) // If string is "", use default device
+                : AudioUtils.DeviceEnumerator.EnumerateAudioEndPoints(flow, DeviceState.Active).FirstOrDefault(d => d.DeviceFriendlyName == deviceName); // Else find device with this name
+
+            // If found device, create a WaveIn for it
+            if (Device != null) {
+                waveIn = new WasapiLoopbackCapture(Device);
+                if (waveInDataAvailable != null)
+                    waveIn.DataAvailable += waveInDataAvailable;
+                waveIn.StartRecording();
+            }
+        }
+
+        #region IDisposable Support
+        private bool disposedValue = false; // To detect redundant calls
+
+        protected virtual void Dispose(bool disposing) {
+            if (!disposedValue) {
+                if (disposing)
+                    DisposeDeviceAndWaveIn();
+                disposedValue = true;
+            }
+        }
+
+        public void Dispose() => Dispose(true);
+
+        private void DisposeDeviceAndWaveIn() {
+            Device?.Dispose();
+            Device = null;
+            waveIn?.StopRecording();
+            waveIn?.Dispose();
+            waveIn = null;
+        }
+        #endregion
+    }
+
+    public static class AudioUtils {
+
+        internal const string DEVICE_DEFAULT = "Default";
+
+        public static MMDeviceEnumerator DeviceEnumerator { get; } = new MMDeviceEnumerator();
+
+        public static ObservableCollection<string> PlaybackDevices { get; } = new ObservableCollection<string>(DeviceEnumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active).Select(x => x.DeviceFriendlyName));
+        public static ObservableCollection<string> RecordingDevices { get; } = new ObservableCollection<string>(DeviceEnumerator.EnumerateAudioEndPoints(DataFlow.Capture, DeviceState.Active).Select(x => x.DeviceFriendlyName));
+    }
+}

--- a/Project-Aurora/Project-Aurora/Utils/AudioUtils.cs
+++ b/Project-Aurora/Project-Aurora/Utils/AudioUtils.cs
@@ -19,7 +19,7 @@ namespace Aurora.Utils {
         private readonly DataFlow flow;
         private bool enableRecording = true;
         private string deviceName;
-        private WasapiLoopbackCapture waveIn;
+        private WasapiCapture waveIn;
         private EventHandler<WaveInEventArgs> waveInDataAvailable; // Store the current event listeners so when device changes, we can re-attach listeners
 
 
@@ -76,7 +76,8 @@ namespace Aurora.Utils {
 
             // If found device, create a WaveIn for it
             if (Device != null) {
-                waveIn = new WasapiLoopbackCapture(Device);
+                // For audio output devices, we need to use a loopback capture, but for audio input devices we need a regular capture.
+                waveIn = flow == DataFlow.Render ? new WasapiLoopbackCapture(Device) : new WasapiCapture(Device);
                 
                 // If there are listeners that are currently registered, add them to the new WaveIn
                 if (waveInDataAvailable != null)


### PR DESCRIPTION
Adds options to the Aurora general settings for selecting which audio devices are used to provide the values for the mic and speaker volume levels for the `LocalPCInfo` gamestate.

Also adds an option to the audio visualizer to choose which audio output device to use. Different visualizer layers can use different devices.

Adds a utility class for easier handling of switching audio devices. This class can be given an audio device's name and will gracefully switch over to using that device instead. The class keeps track of any events added to the wave's DataAvailable event and will switch these over automatically also.

Resolves #1784.