### PR TITLE
Add stale GH action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,23 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue has not seen any activity in 90 days and has been flagged as stale. This issue will be closed in 2 weeks.'
+        stale-pr-message: 'This pull request has not seen any activity in 90 days and has been flagged as stale. This pull request will be closed in 2 weeks.'
+        stale-issue-label: 'Status: Stale'
+        stale-pr-label: 'Status: Stale'
+        exempt-pr-label: 'Never stale'
+        exempt-issue-label: 'Never stale'
+        days-before-stale: 90
+        days-before-close: 14
+        
+        operations-per-run: 250


### PR DESCRIPTION
Adds a GH action to mark issues and PRs with the stale label after 90 days (~3 months) of inactivity.
If the issue/PR still has no activity within 2 weeks, it is closed.

Note that the operations-per-run has been set above the default since, at the time of writing, there are a lot of stale issues so we'd like the bot to not spend weeks sorting these. Once the initial ones have been sorted, this could be reset to the default (30) or removed.