### PR TITLE
Fix uncommon crash when deleting custom profile

### DIFF
--- a/Project-Aurora/Project-Aurora/ConfigUI.xaml.cs
+++ b/Project-Aurora/Project-Aurora/ConfigUI.xaml.cs
@@ -617,11 +617,14 @@ namespace Aurora
                 {
                     if (MessageBox.Show("Are you sure you want to delete profile for " + (((Profiles.Application)Global.LightingStateManager.Events[name]).Settings as GenericApplicationSettings).ApplicationName + "?", "Remove Profile", MessageBoxButton.YesNo, MessageBoxImage.Warning) == MessageBoxResult.Yes)
                     {
-                        var eventList = Global.Configuration.ProfileOrder;
-                        string prevProfile = eventList[eventList.FindIndex(s => s.Equals(name)) - 1];
+                        var eventList = Global.Configuration.ProfileOrder
+                            .ToDictionary(x => x, x => Global.LightingStateManager.Events[x])
+                            .Where(x => ShowHidden || !(x.Value as Profiles.Application).Settings.Hidden)
+                            .ToList();
+                        var idx = Math.Max(eventList.FindIndex(x => x.Key == name), 0);
                         Global.LightingStateManager.RemoveGenericProfile(name);
                         //ConfigManager.Save(Global.Configuration);
-                        this.GenerateProfileStack(prevProfile);
+                        this.GenerateProfileStack(eventList[idx].Key);
                     }
                 }
             }


### PR DESCRIPTION
Fixes occasional crash when deleting a custom profile.

This sometimes occured when the previous profile in the list was hidden and the user had not shown the hidden profiles. Aurora would then try to select the item before the one deleted and try to get the average color of the profile's icon and crash (perhaps since the resource hadn't been loaded or something?).

Now, when deleting a profile, it will select the next non-hidden profile.