### PR TITLE
Fix AutoJsonNode crash on node without fields

### DIFF
--- a/Project-Aurora/Project-Aurora/Profiles/AutoJsonNode.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/AutoJsonNode.cs
@@ -41,7 +41,7 @@ namespace Aurora.Profiles {
             }
 
             // Compile and return the action
-            return Lambda<Action<TSelf>>(Block(body), selfParam).Compile();
+            return Lambda<Action<TSelf>>(body.Count == 0 ? (Expression)Empty() : Block(body), selfParam).Compile();
         });
         #endregion
 


### PR DESCRIPTION
Fixed AutoJsonNode crash when it encounters a node with no fields.