### PR TITLE
Update MinecraftApplication.cs

### DIFF
--- a/Project-Aurora/Project-Aurora/Profiles/Minecraft/MinecraftApplication.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/Minecraft/MinecraftApplication.cs
@@ -13,7 +13,7 @@ namespace Aurora.Profiles.Minecraft {
             Name = "Minecraft",
             ID = "minecraft",
             //ProcessNames = new[] { "java.exe", "javaw.exe" },
-            ProcessTitles = new[] { @"^Minecraft\*? [0-9.]*$" }, // Match anything that has a title like "Minecraft 1.12.2" or "Minecraft 1.5")
+            ProcessTitles = new[] { @"^Minecraft\*? [0-9.]*" }, // Match anything that has a title like "Minecraft 1.12.2" or "Minecraft 1.5")
             ProfileType = typeof(MinecraftProfile),
             OverviewControlType = typeof(Control_Minecraft),
             GameStateType = typeof(GSI.GameState_Minecraft),

--- a/Project-Aurora/Project-Aurora/Profiles/Minecraft/MinecraftApplication.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/Minecraft/MinecraftApplication.cs
@@ -13,7 +13,7 @@ namespace Aurora.Profiles.Minecraft {
             Name = "Minecraft",
             ID = "minecraft",
             //ProcessNames = new[] { "java.exe", "javaw.exe" },
-            ProcessTitles = new[] { @"^Minecraft [0-9.]*$" }, // Match anything that has a title like "Minecraft 1.12.2" or "Minecraft 1.5")
+            ProcessTitles = new[] { @"^Minecraft\*? [0-9.]*$" }, // Match anything that has a title like "Minecraft 1.12.2" or "Minecraft 1.5")
             ProfileType = typeof(MinecraftProfile),
             OverviewControlType = typeof(Control_Minecraft),
             GameStateType = typeof(GSI.GameState_Minecraft),


### PR DESCRIPTION
Minecraft title, when it's a modded client, it comes with a "*" on its name.

With this little modification on the regex file the profile will work again on Forge/Fabric modded clients.
