### PR TITLE
Game State Parameter Picker + Enum Game State fix

### DIFF
--- a/Project-Aurora/Project-Aurora/Controls/GameStateParameterPicker.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Controls/GameStateParameterPicker.xaml.cs
@@ -118,7 +118,7 @@ namespace Aurora.Controls {
             }
 
             // Raise an event informing subscribers
-            picker.SelectedPathChanged?.Invoke(picker, new SelectedPathChangedEventArgs(e.OldValue.ToString(), e.NewValue.ToString()));
+            picker.SelectedPathChanged?.Invoke(picker, new SelectedPathChangedEventArgs(e.OldValue?.ToString() ?? "", e.NewValue?.ToString() ?? ""));
         }
         #endregion
 


### PR DESCRIPTION
Fixes issue with the Game State Parameter Picker crashing when a `SelectedPathChanged` handler is attached, the path is currently empty and the user selects a new path; most notably with the enum game state evaluatable.