### PR TITLE
Fix Asus unsupported sdk version handling

### DIFF
--- a/Project-Aurora/Project-Aurora/Devices/Asus/AsusDevice.cs
+++ b/Project-Aurora/Project-Aurora/Devices/Asus/AsusDevice.cs
@@ -51,7 +51,7 @@ namespace Aurora.Devices.Asus
         {
             asusHandler?.Stop();
             
-            asusHandler = new AsusHandler();
+            asusHandler = new AsusHandler(Global.Configuration.VarRegistry.GetVariable<bool>($"{DeviceName}_enable_unsupported_version"));
             isActive = asusHandler.Start();
             return isActive;
         }

--- a/Project-Aurora/Project-Aurora/Devices/Asus/AsusHandler.cs
+++ b/Project-Aurora/Project-Aurora/Devices/Asus/AsusHandler.cs
@@ -25,11 +25,11 @@ namespace Aurora.Devices.Asus
         /// </summary>
         public bool HasSdk => AuraSdk != null;
 
-        public AsusHandler()
+        public AsusHandler(bool enableUnsupportedVersion = false)
         {
             try
             {
-                if (CheckVersion(out string message))
+                if (CheckVersion(enableUnsupportedVersion, out string message))
                     AuraSdk = new AuraSdk() as IAuraSdk2;
                 else
                     AuraSdk = null;
@@ -47,12 +47,10 @@ namespace Aurora.Devices.Asus
         /// Checks to see if the version of Aura installed is the correct one
         /// </summary>
         /// <returns>true if the registry entry equals to <see cref="RecommendedAsusVersion"/></returns>
-        private bool CheckVersion(out string message)
+        private bool CheckVersion(bool enableUnsupportedVersion, out string message)
         {
             message = null;
-            
-            bool enableUnsupportedVersion = Global.Configuration.VarRegistry.GetVariable<bool>($"{DeviceName}_disconnect_when_stop");
-            
+
             //Computer\HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Asus\AURA\Version
             using (var root = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32))
             {

--- a/Project-Aurora/Project-Aurora/Devices/Asus/Config/AsusConfigWindow.xaml.cs
+++ b/Project-Aurora/Project-Aurora/Devices/Asus/Config/AsusConfigWindow.xaml.cs
@@ -73,7 +73,7 @@ namespace Aurora.Devices.Asus.Config
 
         private bool LoadAuraSdk()
         {
-            asusHandler = new AsusHandler();
+            asusHandler = new AsusHandler(Global.Configuration.VarRegistry.GetVariable<bool>($"Asus_enable_unsupported_version"));
             asusHandler.AuraSdk?.SwitchMode();
 
             if (asusHandler.HasSdk)


### PR DESCRIPTION
This pr fix the following issues:
The the problem is that when the first time asusHandler constructor was called the varRegistry is not yet registered so it going to throw exception which i think not intended behavior
The other problem the registered varRegistry name is not equals with get part 