### PR TITLE
Fixed issue where desktop overlays are rendered multiple times.

### DIFF
--- a/Project-Aurora/Project-Aurora/Profiles/Desktop/Event_Desktop.cs
+++ b/Project-Aurora/Project-Aurora/Profiles/Desktop/Event_Desktop.cs
@@ -25,8 +25,7 @@ namespace Aurora.Profiles.Desktop
         public override void UpdateLights(EffectFrame frame)
         {
             var layers = new Queue<EffectLayer>(Application.Profile.Layers.Where(l => l.Enabled).Reverse().Select(l => l.Render(_game_state)));
-            var overlayLayers = new Queue<EffectLayer>(Application.Profile.OverlayLayers.Where(l => l.Enabled).Reverse().Select(l => l.Render(_game_state)));
-
+            
             //Scripts before interactive and shortcut assistant layers
             //ProfilesManager.DesktopProfile.UpdateEffectScripts(layers);
 
@@ -43,7 +42,6 @@ namespace Aurora.Profiles.Desktop
             }
 
             frame.AddLayers(layers.ToArray());
-            frame.AddOverlayLayers(overlayLayers.ToArray());
         }
 
         public override void SetGameState(IGameState new_game_state)


### PR DESCRIPTION
Fixed an issue where overlay layers on the desktop profile were being updated twice in a single frame when either the Aurora window was not focused or the desktop was being previewed while "Show Overlays in Application Preview" is checked.

This was particularly noticable with the particle layer. Creating one as a normal layer and one as an overlay demonstrates the issue.