### PR TITLE
Fixed hardware monitor value smoothing

### DIFF
--- a/Project-Aurora/Project-Aurora/Settings/Configuration.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Configuration.cs
@@ -555,7 +555,7 @@ namespace Aurora.Settings
             devices_disabled.Add(typeof(Devices.Dualshock.DualshockDevice));
             devices_disabled.Add(typeof(Devices.AtmoOrbDevice.AtmoOrbDevice));
             devices_disabled.Add(typeof(Devices.NZXT.NZXTDevice));
-            OverlaysInPreview = false;
+            OverlaysInPreview = true;
 
             //Blackout and Night theme
             time_based_dimming_enabled = false;


### PR DESCRIPTION
had one queue per hardware, which makes no sense. now has one queue per *sensor*, having a dictionary per hardware to store these queues.
also makes overlays render in preview by default.