### PR TITLE
Map OpenRGB mouse mat LEDs to Aurora mousepad lights

### DIFF
--- a/Project-Aurora/Project-Aurora/Devices/OpenRGB/OpenRGBDevice.cs
+++ b/Project-Aurora/Project-Aurora/Devices/OpenRGB/OpenRGBDevice.cs
@@ -90,10 +90,20 @@ namespace Aurora.Devices.OpenRGB
                         {
                             for (int k = 0; k < dev.Zones[j].LedCount; k++)
                             {
-                                //TODO - scale zones with more than 32 LEDs
-                                if (k < 32)
+                                if (dev.Type == OpenRGBDeviceType.Mousemat)
                                 {
-                                    _keyMappings[i][(int)(LedOffset + k)] = OpenRGBKeyNames.AdditionalLights[k];
+                                    if (k < 15)
+                                    {
+                                        _keyMappings[i][(int)(LedOffset + k)] = OpenRGBKeyNames.MousepadLights[k];
+                                    }
+                                }
+                                else
+                                {
+                                    //TODO - scale zones with more than 32 LEDs
+                                    if (k < 32)
+                                    {
+                                        _keyMappings[i][(int)(LedOffset + k)] = OpenRGBKeyNames.AdditionalLights[k];
+                                    }
                                 }
                             }
                         }

--- a/Project-Aurora/Project-Aurora/Devices/OpenRGB/OpenRGBKeyNames.cs
+++ b/Project-Aurora/Project-Aurora/Devices/OpenRGB/OpenRGBKeyNames.cs
@@ -149,6 +149,25 @@ namespace Aurora.Devices.OpenRGB
             { "Front"                 , DK.Peripheral_FrontLight  },
         };
 
+        public static readonly List<DK> MousepadLights = new List<DK>(new[]
+        {
+            DK.MOUSEPADLIGHT1,
+            DK.MOUSEPADLIGHT2,
+            DK.MOUSEPADLIGHT3,
+            DK.MOUSEPADLIGHT4,
+            DK.MOUSEPADLIGHT5,
+            DK.MOUSEPADLIGHT6,
+            DK.MOUSEPADLIGHT7,
+            DK.MOUSEPADLIGHT8,
+            DK.MOUSEPADLIGHT9,
+            DK.MOUSEPADLIGHT10,
+            DK.MOUSEPADLIGHT11,
+            DK.MOUSEPADLIGHT12,
+            DK.MOUSEPADLIGHT13,
+            DK.MOUSEPADLIGHT14,
+            DK.MOUSEPADLIGHT15,
+        });
+
         public static readonly List<DK> AdditionalLights = new List<DK>(new[]
         {
             DK.ADDITIONALLIGHT1,


### PR DESCRIPTION
This changes OpenRGB mousemat-type devices with linear zones to use the MOUSEPADLIGHTX lights in Aurora rather than the ADDITIONALLIGHTX lights.  All other linear zones will continue to use ADDITIONALLIGHTX up to 32 lights.