### PR TITLE
Map unknown mouse LEDs to the peripheral logo LED

### DIFF
--- a/Project-Aurora/Project-Aurora/Devices/OpenRGB/OpenRGBDevice.cs
+++ b/Project-Aurora/Project-Aurora/Devices/OpenRGB/OpenRGBDevice.cs
@@ -74,7 +74,7 @@ namespace Aurora.Devices.OpenRGB
                             }
                             else
                             {
-                                _keyMappings[i].Add(DK.NONE);
+                                _keyMappings[i].Add(DK.Peripheral_Logo);
                             }
                         }
                         else


### PR DESCRIPTION
This commit changes the behavior for mapping OpenRGB mouse devices.  Currently, unknown mouse LEDs are mapped to DK.NONE.  Since not all mouse zones are accounted for in the last PR, it's probably sensible to change this so that unknown mouse LEDs are mapped to the peripheral logo, as that is intended for mice anyways.  I'm probably going to release OpenRGB 0.4 without mouse LED labels for Corsair mice due to the mapping being different for each mouse.  I'll have to collect this data from all the supported mice and create a means to select it.  For now, the LEDs are labeled Mouse LED 1, 2, 3...  This change will allow Corsair mice on OpenRGB to work with Aurora even though they'll be a single color.