### PR TITLE
Fix ducky response lag

### DIFF
--- a/Project-Aurora/Project-Aurora/Devices/Ducky/DuckyDevice.cs
+++ b/Project-Aurora/Project-Aurora/Devices/Ducky/DuckyDevice.cs
@@ -194,7 +194,7 @@ namespace Aurora.Devices.Ducky
                     }
                 }
                 colourMessage.CopyTo(prevColourMessage, 0);
-                return true;
+                Thread.Sleep(10);
             }
             return true;
         }

--- a/Project-Aurora/Project-Aurora/Devices/Ducky/DuckyDevice.cs
+++ b/Project-Aurora/Project-Aurora/Devices/Ducky/DuckyDevice.cs
@@ -185,7 +185,7 @@ namespace Aurora.Devices.Ducky
                 }
                 catch (Exception ex)
                 {
-                    Global.logger.Error(ex);
+                    Global.logger.Error(ex, "[DUCKY] Error updating device");
                     Reset();
                     return false;
                 }

--- a/Project-Aurora/Project-Aurora/Devices/Ducky/DuckyDevice.cs
+++ b/Project-Aurora/Project-Aurora/Devices/Ducky/DuckyDevice.cs
@@ -192,7 +192,6 @@ namespace Aurora.Devices.Ducky
                         Reset();
                         return false;
                     }
-                    Thread.Sleep(2);
                 }
                 colourMessage.CopyTo(prevColourMessage, 0);
                 return true;


### PR DESCRIPTION
**Fixes issues:**
Fixes #2086
- Thread sleep is only guaranteed to wait for _atleast_ the delay time specified but can end up waiting longer ([more on this](https://stackoverflow.com/a/8241018/3775593)). For some reason, thread sleep was waiting a lot longer when not debugging which is causing lag when updating the device.
- Without thread sleep, the device hangs.
  - Added stream flushes to ensure full commands are sent
  - Added input report read after device updates

**This pull request proposes the following changes:**
- Move thread sleep call
- Flush hid stream between commands
- Read input report after device updates

**Known issues/To do:**
- Ducky device hung randomly before adding stream flushes and input report read logic
  - After reconnecting the device, it regained responsiveness
  - Since this occurred randomly I have no way to try and repro it to see if it is truly fixed