### PR TITLE
Add configuration option to specify custom port for GameStateListener

### DIFF
--- a/Project-Aurora/Project-Aurora/App.xaml.cs
+++ b/Project-Aurora/Project-Aurora/App.xaml.cs
@@ -376,7 +376,7 @@ namespace Aurora
                 Global.logger.Info("Starting GameStateListener");
                 try
                 {
-                    Global.net_listener = new NetworkListener(9088);
+                    Global.net_listener = new NetworkListener(Global.Configuration.GameStateListenerPort);
                     Global.net_listener.NewGameState += new NewGameStateHandler(Global.LightingStateManager.GameStateUpdate);
                     Global.net_listener.WrapperConnectionClosed += new WrapperConnectionClosedHandler(Global.LightingStateManager.ResetGameState);
                 }

--- a/Project-Aurora/Project-Aurora/Settings/Configuration.cs
+++ b/Project-Aurora/Project-Aurora/Settings/Configuration.cs
@@ -461,6 +461,7 @@ namespace Aurora.Settings
         [JsonProperty("global_brightness")] public float GlobalBrightness { get; set; } = 1.0f;
         [JsonProperty("keyboard_brightness_modifier")] public float KeyboardBrightness { get; set; } = 1.0f;
         [JsonProperty("peripheral_brightness_modifier")] public float PeripheralBrightness { get; set; } = 1.0f;
+        [JsonProperty("gamestatelistener_port")] public ushort GameStateListenerPort { get; set; } = 9088;
 
         public bool GetDevReleases { get; set; } = false;
         public bool GetPointerUpdates { get; set; } = true;


### PR DESCRIPTION
**List any issues that this PR fixes:**
Offers a possible fix/workaround for #2300

**This pull request proposes the following changes:**
- Ability to specify a custom port for GameStateListener for cases where the port might be used or the port range can't be used for whatever reason